### PR TITLE
Remove unnecessary panic when unable to subscribe to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb Lambda Extension Changelog
 
+## Version 3 (2020-11-20)
+
+- Remove unnecessary panic when unable to subscribe to logs API
+- Add version string to user agent header
+
 ## Version 2 (2020-11-12)
 
 - Added option to disable `platform` messages.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOARCH=amd64
 
 build:
 	mkdir -p bin/extensions
-	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/extensions/honeycomb-lambda-extension main.go
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/extensions/honeycomb-lambda-extension .
 
 publish: build
 	cd bin && zip -r extension.zip extensions && aws lambda publish-layer-version --layer-name honeycomb-lambda-extension --region us-east-1 --zip-file "fileb://extension.zip"

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	subRes, err := logsClient.Subscribe(ctx, extensionClient.ExtensionID, logTypes)
 	if err != nil {
-		log.Warn("Could not subscribe to events", err)
+		log.Warn("Could not subscribe to events: ", err)
 	}
 	log.Debug("Response from subscribe: ", subRes)
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -68,6 +69,7 @@ func main() {
 	}
 
 	// initialize libhoney
+	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension/%s", version)
 	client, err := libhoney.NewClient(libhoneyConfig())
 	if err != nil {
 		log.Warn("Could not initialize libhoney", err)

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 
 	subRes, err := logsClient.Subscribe(ctx, extensionClient.ExtensionID, logTypes)
 	if err != nil {
-		log.Panic("Could not subscribe to events", err)
+		log.Warn("Could not subscribe to events", err)
 	}
 	log.Debug("Response from subscribe: ", subRes)
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "0.3.0"
+const version = "3"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const version = "0.3.0"


### PR DESCRIPTION
The extension shouldn't panic when unable to make a successful subscription request to the logs API - just output a warning log message. Also, adding a user agent string with a version.