### PR TITLE
Accept broader range of status codes.

### DIFF
--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -107,7 +107,7 @@ func (c *Client) Subscribe(ctx context.Context, extensionID string, types []LogT
 	if err != nil {
 		return nil, err
 	}
-	if httpRes.StatusCode != 200 {
+	if httpRes.StatusCode >= 400 {
 		return nil, fmt.Errorf("request failed with status %s", httpRes.Status)
 	}
 	defer httpRes.Body.Close()


### PR DESCRIPTION
The Logs API will return a 202 on successful subscribe requests. This
should allow that to succeed, as well as future possible responses that
are not 4xx or 5xx.