### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ workflows:
               only: /.*/
       - build_extension
       - publish_s3:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
* we created a new public context that's identical to the old context,
with the exception of Github token, which is scoped to public repos only
* Github token in the other context is scoped to public and private repos
* (both contexts are still internal to Honeycomb)
* this reduces the security exposure of builds