### PR TITLE
Use circle to publish extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
           name: "Build Binary"
           command: |
             echo "Building extension"
-            mkdir ~/artifacts/
-            GOOS=linux GOARCH=amd64 go build -o ~/artifacts/honeycomb-lambda-extension .
+            mkdir -p ~/artifacts/extensions
+            GOOS=linux GOARCH=amd64 go build -o ~/artifacts/extensions/honeycomb-lambda-extension .
       - persist_to_workspace:
           root: ~/
           paths:
@@ -53,7 +53,7 @@ jobs:
           name: "Artifacts being published"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ~/artifacts/*
+            ls -l ~/artifacts/extensions/*
       - run:
           name: "GHR Draft"
           command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
@@ -72,11 +72,25 @@ jobs:
           name: "Artifacts being published"
           command: |
             echo "about to publish ${CIRCLE_TAG} to S3"
-            ls -l ~/artifacts/*
+            ls -l ~/artifacts/extensions/*
       - run:
           name: "S3 Release"
-          command: aws s3 cp ~/artifacts/honeycomb-lambda-extension s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/honeycomb-lambda-extension
-
+          command: aws s3 cp ~/artifacts/extensions/honeycomb-lambda-extension s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/honeycomb-lambda-extension
+  publish_aws:
+    docker:
+      - image: circleci/golang:1.15
+    steps:
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+          name: "Publish extension to AWS"
+          command: ./publish.sh
 workflows:
   nightly:
     triggers:
@@ -93,7 +107,6 @@ workflows:
               goversion:
                 - "1.14"
                 - "1.15"
-
   build:
     jobs:
       - test:
@@ -103,6 +116,16 @@ workflows:
               only: /.*/
       - build_extension
       - publish_s3:
+          context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          requires:
+            - test
+            - build_extension
+      - publish_github:
           context: Honeycomb Secrets for Public Repos
           filters:
             tags:

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ build:
 
 publish: build
 	cd bin && zip -r extension.zip extensions && aws lambda publish-layer-version --layer-name honeycomb-lambda-extension --region us-east-1 --zip-file "fileb://extension.zip"
+
+publish-dev: build
+	cd bin && zip -r extension.zip extensions && aws lambda publish-layer-version --layer-name honeycomb-lambda-extension-dev --region us-east-1 --zip-file "fileb://extension.zip"

--- a/main.go
+++ b/main.go
@@ -142,7 +142,6 @@ func libhoneyConfig() libhoney.ClientConfig {
 		APIKey:  apiKey,
 		Dataset: dataset,
 		APIHost: apiHost,
-		Logger:  &libhoney.DefaultLogger{},
 	}
 }
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [[ -z "${CIRCLE_TAG}" ]]; then
+	EXTENSION_NAME="honeycomb-lambda-extension-dev"
+else
+	EXTENSION_NAME="honeycomb-lambda-extension"
+fi
+
+REGIONS=`aws ec2 describe-regions | jq -r '.Regions[].RegionName'`
+
+if [ ! -f ~/artifacts/extensions/honeycomb-lambda-extension ]; then
+    echo "extension does not exist, cannot publish."
+    exit 1;
+fi
+
+cd ~/artifacts
+zip -r extension.zip extensions
+
+for region in $REGIONS; do
+    RESPONSE=`aws lambda publish-layer-version \
+        --layer-name $EXTENSION_NAME \
+        --region $region --zip-file "fileb://extension.zip"`
+    VERSION=`echo $RESPONSE | jq -r '.Version'`
+    aws --region $region lambda add-layer-version-permission --layer-name $EXTENSION_NAME \
+        --version-number $VERSION --statement-id "honeycombLambdaExtensionDev-$VERSION-$region" \
+        --principal "*" --action lambda:GetLayerVersion
+done


### PR DESCRIPTION
When publishing a lambda layer, `aws lambda publish-layer-version` must be run for each region as well as `aws lambda add-layer-version-permission` granting all accounts `lambda:GetLayerVersion`. 

This PR adds a script to do the publishing, and tries to wire it up to CircleCI so that a dev build is published on each run, and a main build is published on tags.

Also, set Logger to default (nil) - this will prevent debug output from possibly being emitted by libhoney.