### PR TITLE
automate publishing of honeycomb-extension through CI and tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,11 @@ workflows:
           context: Honeycomb Secrets for Public Repos
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           requires:
             - test
             - build_extension

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,11 @@ workflows:
             - build_extension
       - publish_aws:
           context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
           requires:
             - test
             - build_extension

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,29 @@ jobs:
           name: "Build Binary"
           command: |
             echo "Building extension"
-            mkdir ~/artifacts/
-            GOOS=linux GOARCH=amd64 go build -o ~/artifacts/honeycomb-lambda-extension .
+            mkdir -p ~/artifacts/extensions
+            GOOS=linux GOARCH=amd64 go build -o ~/artifacts/extensions/honeycomb-lambda-extension .
       - persist_to_workspace:
           root: ~/
           paths:
             - artifacts
       - store_artifacts:
           path: ~/artifacts
+  publish_aws:
+    docker:
+      - image: circleci/golang:1.15
+    steps:
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+          name: "Publish extension to AWS"
+          command: ./publish.sh
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0
@@ -101,7 +116,8 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build_extension
+      - build_extension:
+          context: Honeycomb Secrets for Public Repos
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
           filters:
@@ -109,6 +125,11 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+          requires:
+            - test
+            - build_extension
+      - publish_aws:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test
             - build_extension

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,11 @@ workflows:
               only: /.*/
       - build_extension:
           context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,10 @@ jobs:
           name: "Artifacts being published"
           command: |
             echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ~/artifacts/*
+            ls -l ~/artifacts/extensions/*
       - run:
           name: "GHR Draft"
-          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts/extensions/
   publish_s3:
     docker:
       - image: circleci/golang:1.15
@@ -87,10 +87,10 @@ jobs:
           name: "Artifacts being published"
           command: |
             echo "about to publish ${CIRCLE_TAG} to S3"
-            ls -l ~/artifacts/*
+            ls -l ~/artifacts/extensions/*
       - run:
           name: "S3 Release"
-          command: aws s3 cp ~/artifacts/honeycomb-lambda-extension s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/honeycomb-lambda-extension
+          command: aws s3 cp ~/artifacts/extensions/honeycomb-lambda-extension s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/honeycomb-lambda-extension
 
 workflows:
   nightly:
@@ -120,11 +120,6 @@ workflows:
           context: Honeycomb Secrets for Public Repos
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
           requires:
             - test
             - build_extension

--- a/publish.sh
+++ b/publish.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [[ -z "${CIRCLE_TAG}" ]]; then
+if [[ "${CIRCLE_TAG}" == *dev ]]; then
     EXTENSION_NAME="honeycomb-lambda-extension-dev"
 else
     EXTENSION_NAME="honeycomb-lambda-extension"
 fi
 
-REGIONS=(eu-north1 ap-south-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1
+REGIONS=(eu-north-1 ap-south-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1
          sa-east-1 ca-central-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1
          us-east-2 us-west-1 us-west-2)
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ -z "${CIRCLE_TAG}" ]]; then
+    EXTENSION_NAME="honeycomb-lambda-extension-dev"
+else
+    EXTENSION_NAME="honeycomb-lambda-extension"
+fi
+
+REGIONS=(eu-north1 ap-south-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1
+         sa-east-1 ca-central-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1
+         us-east-2 us-west-1 us-west-2)
+
+if [ ! -f ~/artifacts/extensions/honeycomb-lambda-extension ]; then
+    echo "extension does not exist, cannot publish."
+    exit 1;
+fi
+
+cd ~/artifacts
+zip -r extension.zip extensions
+
+for region in ${REGIONS[@]}; do
+    RESPONSE=`aws lambda publish-layer-version \
+        --layer-name $EXTENSION_NAME \
+        --region $region --zip-file "fileb://extension.zip"`
+    VERSION=`echo $RESPONSE | jq -r '.Version'`
+    aws --region $region lambda add-layer-version-permission --layer-name $EXTENSION_NAME \
+        --version-number $VERSION --statement-id "$EXTENSION_NAME-$VERSION-$region" \
+        --principal "*" --action lambda:GetLayerVersion
+done


### PR DESCRIPTION
Instead of manually releasing the honeycomb-lambda-extension, we can now rely on CI to deploy a new version on tags. If the tag has a suffix of "dev", such as `v5.0.0dev`, then the extension will be published as `honeycomb-lambda-extension-dev`. This will be handy for pre-release testing.