### PR TITLE
Use timestamps from body of log message

### DIFF
--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -22,7 +22,7 @@ type LogType string
 
 const (
 	// Local hostname according to process running in extension env
-	localHostname= "sandbox"
+	localHostname = "sandbox"
 
 	// HTTPProtocol is the protocol that we receive logs over
 	HTTPProtocol Protocol = "HTTP"

--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -10,8 +10,6 @@ import (
 	"net/url"
 	"path"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Protocol represents the protocol that this extension should receive logs by
@@ -116,9 +114,6 @@ func (c *Client) Subscribe(ctx context.Context, extensionID string, types []LogT
 		return nil, err
 	}
 	c.ExtensionID = httpRes.Header.Get(extensionIdentifierHeader)
-	if len(c.ExtensionID) == 0 {
-		log.Warn("No extension identifier returned in header")
-	}
 	return &SubscribeResponse{
 		Message: string(body),
 	}, nil

--- a/logsapi/server.go
+++ b/logsapi/server.go
@@ -118,16 +118,16 @@ func parseFunctionTimestamp(msg LogMessage, body map[string]interface{}) time.Ti
 	if ok {
 		// duration_ms may be a float (e.g. 43.23), integer (e.g. 54) or a string (e.g. "43")
 		switch duration := dur.(type) {
-			case float64:
-				if d, err := time.ParseDuration(fmt.Sprintf("%.4fms", duration)); err == nil {
-					return messageTime.Add(-1 * d)
-				}
-			case int64:
-				return messageTime.Add(-1 * (time.Duration(duration) * time.Millisecond))
-			case string:
-				if d, err := strconv.ParseFloat(duration, 64); err == nil {
-					return messageTime.Add(-1 * (time.Duration(d) * time.Millisecond))
-				}
+		case float64:
+			if d, err := time.ParseDuration(fmt.Sprintf("%.4fms", duration)); err == nil {
+				return messageTime.Add(-1 * d)
+			}
+		case int64:
+			return messageTime.Add(-1 * (time.Duration(duration) * time.Millisecond))
+		case string:
+			if d, err := strconv.ParseFloat(duration, 64); err == nil {
+				return messageTime.Add(-1 * (time.Duration(d) * time.Millisecond))
+			}
 		}
 	}
 

--- a/logsapi/server_test.go
+++ b/logsapi/server_test.go
@@ -102,6 +102,14 @@ func TestLogMessage(t *testing.T) {
 	assert.Equal(t, "bar", events[2].Data["foo"])
 }
 
+func TestTimestampsFunctionMessageNoJson(t *testing.T) {
+	events := postMessages(t, []LogMessage{nonJsonFunctionMessage})
+	event := events[0]
+
+	ts, _ := time.Parse(time.RFC3339, "2020-11-03T21:10:25.150Z")
+	assert.Equal(t, ts.String(), event.Timestamp.String())
+}
+
 func TestTimestampsPlatformMessage(t *testing.T) {
 	events := postMessages(t, []LogMessage{platformStartMessage})
 	event := events[0]

--- a/logsapi/server_test.go
+++ b/logsapi/server_test.go
@@ -3,6 +3,7 @@ package logsapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,37 +15,58 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getLogMessages() []LogMessage {
-	return []LogMessage{
-		{
-			Time: "2020-11-03T21:10:25.133Z",
-			Type: "platform.start",
-			Record: map[string]string{
-				"requestId": "6d67e385-053d-4622-a56f-b25bcef23083",
-				"version":   "$LATEST",
-			},
-		},
-		{
-			Time:   "2020-11-03T21:10:25.150Z",
-			Type:   "function",
-			Record: "A basic message to STDOUT",
-		},
-		{
-			Time:   "2020-11-03T21:10:25.150Z",
-			Type:   "function",
-			Record: "{\"foo\": \"bar\", \"duration_ms\": \"54\"}",
-		},
-		{
-			Time:   "2020-11-03T21:10:25.150Z",
-			Type:   "function",
-			Record: "{\"foo\": \"bar\", \"duration_ms\": 54, \"timestamp\": \"2020-11-03T21:10:25.090Z\"}",
+var (
+	platformStartMessage = LogMessage{
+		Time: "2020-11-03T21:10:25.133Z",
+		Type: "platform.start",
+		Record: map[string]string{
+			"requestId": "6d67e385-053d-4622-a56f-b25bcef23083",
+			"version":   "$LATEST",
 		},
 	}
-}
 
-func TestLogMessage(t *testing.T) {
+	nonJsonFunctionMessage = LogMessage{
+		Time:   "2020-11-03T21:10:25.150Z",
+		Type:   "function",
+		Record: "A basic message to STDOUT",
+	}
+
+	functionMessageWithStringDurationNoTimestamp = LogMessage{
+		Time:   "2020-11-03T21:10:25.150Z",
+		Type:   "function",
+		Record: "{\"foo\": \"bar\", \"duration_ms\": \"54\"}",
+	}
+
+	functionMessageWithIntDurationNoTimestamp = LogMessage{
+		Time:   "2020-11-03T21:10:25.150Z",
+		Type:   "function",
+		Record: "{\"foo\": \"bar\", \"duration_ms\": 54}",
+	}
+
+	functionMessageWithFloatDurationNoTimestamp = LogMessage{
+		Time:   "2020-11-03T21:10:25.150Z",
+		Type:   "function",
+		Record: "{\"foo\": \"bar\", \"duration_ms\": 54.43}",
+	}
+
+	functionMessageWithTimestamp = LogMessage{
+		Time:   "2020-11-03T21:10:25.150Z",
+		Type:   "function",
+		Record: "{\"foo\": \"bar\", \"duration_ms\": 54, \"timestamp\": \"2020-11-03T21:10:25.090Z\"}",
+	}
+
+	logMessages = []LogMessage{
+		platformStartMessage,
+		nonJsonFunctionMessage,
+		functionMessageWithStringDurationNoTimestamp,
+		functionMessageWithIntDurationNoTimestamp,
+		functionMessageWithTimestamp,
+	}
+)
+
+func postMessages(t *testing.T, messages []LogMessage) []*transmission.Event {
 	rr := httptest.NewRecorder()
-	b, err := json.Marshal(getLogMessages())
+	b, err := json.Marshal(messages)
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,44 +74,84 @@ func TestLogMessage(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 	testTx := &transmission.MockSender{}
 	client, _ := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: testTx,
 		APIKey:       "blah",
 	})
 	handler(client).ServeHTTP(rr, req)
-
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
+	return testTx.Events()
+}
 
-	assert.Equal(t, 4, len(testTx.Events()))
-	assert.Equal(t, "platform.start", testTx.Events()[0].Data["lambda_extension.type"])
-	assert.Equal(t, "$LATEST", testTx.Events()[0].Data["version"])
-	assert.Equal(t, "bar", testTx.Events()[2].Data["foo"])
+func TestLogMessage(t *testing.T) {
+	events := postMessages(t, logMessages)
 
-	// try to parse the timestamp from the event body of a platform message
+	assert.Equal(t, 5, len(events))
+
+	assert.Equal(t, "platform.start", events[0].Data["lambda_extension.type"])
+	assert.Equal(t, "function", events[1].Data["lambda_extension.type"])
+	assert.Equal(t, "function", events[2].Data["lambda_extension.type"])
+	assert.Equal(t, "function", events[3].Data["lambda_extension.type"])
+
+	assert.Equal(t, "$LATEST", events[0].Data["version"])
+	assert.Equal(t, "A basic message to STDOUT", events[1].Data["record"])
+	assert.Equal(t, "bar", events[2].Data["foo"])
+}
+
+func TestTimestampsPlatformMessage(t *testing.T) {
+	events := postMessages(t, []LogMessage{platformStartMessage})
+	event := events[0]
+
+	// try to parse the timestamp from the Time field of a platform message
 	ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.133Z")
 	if err != nil {
 		assert.Fail(t, "Could not parse timestamp")
 	}
-	assert.Equal(t, ts.String(), testTx.Events()[0].Timestamp.String())
+	assert.Equal(t, ts.String(), event.Timestamp.String())
+}
+
+func TestTimestampsFunctionMessageWithTimestamp(t *testing.T) {
+	events := postMessages(t, []LogMessage{functionMessageWithTimestamp})
+	event := events[0]
 
 	// try to parse the timestamp from the event body of a function message
-	ts, err = time.Parse(time.RFC3339, "2020-11-03T21:10:25.090Z")
+	ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.090Z")
 	if err != nil {
 		assert.Fail(t, "Could not parse timestamp")
 	}
-	assert.Equal(t, ts.String(), testTx.Events()[3].Timestamp.String())
+	assert.Equal(t, ts.String(), event.Timestamp.String())
+}
+
+func TestTimestampsFunctionMessageWithDuration(t *testing.T) {
+	events := postMessages(t, []LogMessage{
+		functionMessageWithStringDurationNoTimestamp,
+		functionMessageWithIntDurationNoTimestamp,
+	})
 
 	// when no timestamp is present in the body, take the event timestamp and subtract duration
-	ts, err = time.Parse(time.RFC3339, "2020-11-03T21:10:25.150Z")
+	for _, event := range events {
+		ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.150Z")
+		if err != nil {
+			assert.Fail(t, "Could not parse timestamp")
+		}
+		d := 54 * time.Millisecond
+		ts = ts.Add(-1 * d)
+		assert.Equal(t, ts.String(), event.Timestamp.String())
+	}
+
+	events = postMessages(t, []LogMessage{functionMessageWithFloatDurationNoTimestamp})
+	event := events[0]
+
+	ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.150Z")
 	if err != nil {
 		assert.Fail(t, "Could not parse timestamp")
 	}
-	d := 54 * time.Millisecond
+	d, _ := time.ParseDuration(fmt.Sprintf("%.4fms", 54.43))
 	ts = ts.Add(-1 * d)
-	assert.Equal(t, ts.String(), testTx.Events()[2].Timestamp.String())
+	assert.Equal(t, ts.String(), event.Timestamp.String())
+
 }

--- a/logsapi/server_test.go
+++ b/logsapi/server_test.go
@@ -3,7 +3,6 @@ package logsapi
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +22,6 @@ func getLogMessages() []LogMessage {
 			Record: map[string]string{
 				"requestId": "6d67e385-053d-4622-a56f-b25bcef23083",
 				"version":   "$LATEST",
-				"timestamp": "2020-11-03T21:10:25.150Z",
 			},
 		},
 		{
@@ -34,12 +32,12 @@ func getLogMessages() []LogMessage {
 		{
 			Time:   "2020-11-03T21:10:25.150Z",
 			Type:   "function",
-			Record: "{\"foo\": \"bar\", \"duration_ms\": \"54ms\"}",
+			Record: "{\"foo\": \"bar\", \"duration_ms\": \"54\"}",
 		},
 		{
 			Time:   "2020-11-03T21:10:25.150Z",
 			Type:   "function",
-			Record: "{\"foo\": \"bar\", \"duration_ms\": \"54ms\", \"timestamp\": \"2020-11-03T21:10:25.090Z\"}",
+			Record: "{\"foo\": \"bar\", \"duration_ms\": 54, \"timestamp\": \"2020-11-03T21:10:25.090Z\"}",
 		},
 	}
 }
@@ -73,7 +71,7 @@ func TestLogMessage(t *testing.T) {
 	assert.Equal(t, "bar", testTx.Events()[2].Data["foo"])
 
 	// try to parse the timestamp from the event body of a platform message
-	ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.150Z")
+	ts, err := time.Parse(time.RFC3339, "2020-11-03T21:10:25.133Z")
 	if err != nil {
 		assert.Fail(t, "Could not parse timestamp")
 	}
@@ -91,11 +89,7 @@ func TestLogMessage(t *testing.T) {
 	if err != nil {
 		assert.Fail(t, "Could not parse timestamp")
 	}
-	duration := fmt.Sprintf("%s", testTx.Events()[2].Data["duration_ms"])
-	d, err := time.ParseDuration(duration)
-	if err != nil {
-		assert.Fail(t, "Could not parse duration")
-	}
+	d := 54 * time.Millisecond
 	ts = ts.Add(-1 * d)
 	assert.Equal(t, ts.String(), testTx.Events()[2].Timestamp.String())
 }


### PR DESCRIPTION
Fixes #11. The AWS Lambda Logs API provides `function` and `platform` log messages. For `platform` messages (such as function invocation start and end events), use the log message timestamp. For function log messages, which are events written to standard output from a lambda function, look to see if there is a provided timestamp in the string encoded JSON body of the message event. If there is, use it. If not, look to see if there is a `duration_ms` field in the string encoded JSON body. If a duration exists, take the log message timestamp and subtract the duration to get an approximation of start time for the span. If neither of these fields exists, or if the log message body is not JSON, just use the log message timestamp like we do for `platform` messages.