### PR TITLE
Flush events queue on wake up

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,6 +119,8 @@ func main() {
 				log.Warn("Error from NextEvent: ", err)
 				continue
 			}
+			// Flush events queue after waking up
+			client.Flush()
 			if res.EventType == extension.Shutdown {
 				log.Debug("Received SHUTDOWN event. Exiting.")
 				cancel()


### PR DESCRIPTION
- extension freezes between lambda invocations
- flushing events on every wake is more deterministic
- following aws example: https://github.com/aws-samples/aws-lambda-extensions/blob/b11f8b4ea115bb16eb00603c88e21563f849b15b/go-example-logs-api-extension/main.go#L100