### PR TITLE
Prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ shutdown events.
 To use the honeycomb-lambda-extension with a lambda function, it must be configured as a layer. This can be done with the aws CLI tool:
 
 ```
-$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension:2"
+$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension:6"
 ```
 
 Substituting `<AWS_REGION>` for the AWS region you want to deploy this in.
@@ -47,7 +47,7 @@ resource "aws_lambda_function" "extensions-demo-example-lambda-python" {
         }
         
         layers = [
-            "arn:aws:lambda:us-east-1:702835727665:layer:honeycomb-lambda-extension:2"
+            "arn:aws:lambda:us-east-1:702835727665:layer:honeycomb-lambda-extension:6"
         ]
 }
 ```

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "4"
+const version = "6"


### PR DESCRIPTION
- version is used in libhoney agent string (looks like we missed updating it for last release)
- tags are ahead of extension version :(
- this will be extension version 6, tag v7.0.0