### PR TITLE
add some configurable logging

### DIFF
--- a/extension/client.go
+++ b/extension/client.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // EventType represents the type of events received from /event/next
@@ -28,6 +29,25 @@ const (
 	// extensionIdentifierHeader is a uuid that is required on subsequent requests
 	extensionIdentifierHeader = "Lambda-Extension-Identifier"
 )
+
+var (
+	// set up logging defaults for our own logging output
+	log = logrus.WithFields(logrus.Fields{
+		"source": "hny-lambda-ext-client",
+	})
+)
+
+func init() {
+	envLogLevel, ok := os.LookupEnv("HNY_LOG_LEVEL")
+	if !ok {
+		envLogLevel = "info"
+	}
+	parsedLogLevel, err := logrus.ParseLevel(envLogLevel)
+	if err != nil {
+		parsedLogLevel = logrus.InfoLevel
+	}
+	logrus.SetLevel(parsedLogLevel)
+}
 
 // Client is used to communicate with the Extensions API
 type Client struct {

--- a/extension/client.go
+++ b/extension/client.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 
@@ -36,18 +35,6 @@ var (
 		"source": "hny-lambda-ext-client",
 	})
 )
-
-func init() {
-	envLogLevel, ok := os.LookupEnv("HNY_LOG_LEVEL")
-	if !ok {
-		envLogLevel = "info"
-	}
-	parsedLogLevel, err := logrus.ParseLevel(envLogLevel)
-	if err != nil {
-		parsedLogLevel = logrus.InfoLevel
-	}
-	logrus.SetLevel(parsedLogLevel)
-}
 
 // Client is used to communicate with the Extensions API
 type Client struct {

--- a/logsapi/server.go
+++ b/logsapi/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -26,18 +25,6 @@ var (
 		"source": "hny-lambda-ext-logsapi",
 	})
 )
-
-func init() {
-	envLogLevel, ok := os.LookupEnv("HNY_LOG_LEVEL")
-	if !ok {
-		envLogLevel = "info"
-	}
-	parsedLogLevel, err := logrus.ParseLevel(envLogLevel)
-	if err != nil {
-		parsedLogLevel = logrus.InfoLevel
-	}
-	logrus.SetLevel(parsedLogLevel)
-}
 
 // handler receives batches of log messages from the Lambda Logs API. Each
 // LogMessage is sent to Honeycomb as a separate event.

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 
 	libhoney "github.com/honeycombio/libhoney-go"
-	log "github.com/sirupsen/logrus"
+	logrus "github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/honeycomb-lambda-extension/extension"
 	"github.com/honeycombio/honeycomb-lambda-extension/logsapi"
@@ -42,7 +42,24 @@ var (
 	// when run in local mode, we don't attempt to register the extension or subscribe
 	// to log events - useful for testing
 	localMode = false
+
+	// set up logging defaults for our own logging output
+	log = logrus.WithFields(logrus.Fields{
+		"source": "hny-lambda-ext-main",
+	})
 )
+
+func init() {
+	envLogLevel, ok := os.LookupEnv("HNY_LOG_LEVEL")
+	if !ok {
+		envLogLevel = "info"
+	}
+	parsedLogLevel, err := logrus.ParseLevel(envLogLevel)
+	if err != nil {
+		parsedLogLevel = logrus.InfoLevel
+	}
+	logrus.SetLevel(parsedLogLevel)
+}
 
 func main() {
 	flag.BoolVar(&localMode, "localMode", false, "do not attempt to register or subscribe")


### PR DESCRIPTION
logrus was never told what level to log at, so we wouldn't see debug statements.

Adds some debug statements to the logsapi.handler which is the most interesting place for learning what's going on in the parsing of log output and its transformation into Honeycomb events.

![log by blammo](https://user-images.githubusercontent.com/517302/117386650-45e6cf80-aeb5-11eb-8be2-fae4216425d5.gif)
