### PR TITLE
move the minutia of build into the Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,8 @@ jobs:
       - go/mod-download
       - go/save-cache
       - run:
-          name: "Build Binary"
-          command: |
-            echo "Building extension"
-            mkdir -p ~/artifacts/extensions
-            GOOS=linux GOARCH=amd64 go build -o ~/artifacts/extensions/honeycomb-lambda-extension .
+          name: "Build Binary & Extension ZIP"
+          command: make build zip
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,15 @@ orbs:
   go: circleci/go@1.5.0
   aws-cli: circleci/aws-cli@0.1.13
 
+matrix_aws_regions: &matrix_aws_regions
+  matrix:
+    parameters:
+      aws_region: [ "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2",
+                    "ca-central-1",
+                    "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3",
+                    "sa-east-1",
+                    "us-east-1", "us-east-2", "us-west-1", "us-west-2" ]
+
 jobs:
   test:
     parameters:
@@ -43,6 +52,9 @@ jobs:
   publish_aws:
     docker:
       - image: circleci/golang:1.15
+    parameters:
+      aws_region:
+        type: string
     steps:
       - attach_workspace:
           at: ~/
@@ -51,10 +63,11 @@ jobs:
       - aws-cli/configure:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
       - run:
           name: "Publish extension to AWS"
-          command: ./publish.sh
+          command: make publish_aws
+          environment:
+            AWS_REGION: << parameters.aws_region >>
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0
@@ -132,6 +145,7 @@ workflows:
             - build_extension
       - publish_aws:
           context: Honeycomb Secrets for Public Repos
+          <<: *matrix_aws_regions
           filters:
             tags:
               only: /^v.*/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,72 @@
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rule
+
+.PHONY: build publish check-env clean test
 GOOS=linux
 GOARCH=amd64
 
-build:
-	mkdir -p bin/extensions
-	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/extensions/honeycomb-lambda-extension .
+EXTENSION = honeycomb-lambda-extension
+GO_SOURCES := main.go $(wildcard *.go) go.mod go.sum
 
-publish: build
-	cd bin && zip -r extension.zip extensions && aws lambda publish-layer-version --layer-name honeycomb-lambda-extension --region us-east-1 --zip-file "fileb://extension.zip"
+ARTIFACTS_DIR=artifacts
+#: where release artifacts will be built
+$(ARTIFACTS_DIR):
+	@mkdir -p $@
+
+EXTENSION_DIR=$(ARTIFACTS_DIR)/extensions
+EXECUTABLE=$(EXTENSION_DIR)/$(EXTENSION)
+EXTENSION_ZIP=$(ARTIFACTS_DIR)/extension.zip
+
+#: where the contents of the extention will be gathered
+$(EXTENSION_DIR):
+	@mkdir -p $@
+
+#: compile the extension executable
+build: $(EXECUTABLE)
+#: the extension's executable
+$(EXECUTABLE): $(EXTENSION_DIR) $(GO_SOURCES)
+	@echo "+++ building: $@"
+	GOOS=${GOOS} GOARCH=${GOARCH} \
+		go build -ldflags "-s -w" \
+		-o $@ .
+
+#: publish the extension as a lambda layer to a specified AWS_REGION
+publish_aws: zip
+	@:$(call check_defined, AWS_REGION, the region to which the extension will be published)
+	@echo "+++ publishing $(EXTENSION) to $(AWS_REGION)"
+	aws lambda publish-layer-version \
+		--layer-name $(EXTENSION) \
+		--region $(AWS_REGION) \
+		--zip-file "fileb://$(EXTENSION_ZIP)"
+
+#: package up the extension in a ZIP file
+zip: $(EXTENSION_ZIP)
+#: the extension's zipfile for publishing to Amazon
+$(EXTENSION_ZIP): $(EXECUTABLE)
+	@echo "+++ zipping: $@"
+	cd $(ARTIFACTS_DIR) && zip -r extension.zip extensions
+
+COVERPROFILE=cover-source.out
+#: run tests with coverage report
+test:
+	@echo "+++ testing"
+	go test -v -race -count=1 -coverprofile=$(COVERPROFILE) -failfast -p 1 -covermode=atomic  ./...
+
+#: clean up from builds and tests
+clean:
+	@echo "+++ clean up, clean up, everybody, everywhere"
+	rm -rf $(ARTIFACTS_DIR)
+	rm -rf $(COVERPROFILE)
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+        $(error Undefined $1$(if $2, ($2))$(if $(value @), \
+                required by target `$@')))
+


### PR DESCRIPTION
### Makefile updates

* Leaned heavily into make target dependencies to build up to producing the ZIP file for the layer.

* Added a 'make test` target for convienence in dev. The CircleCI config uses a go orb's default for test execution.

* Includes comments for targets that produce help text when used with [remake](https://github.com/rocky/remake):

```
» remake --tasks
artifacts            where release artifacts will be built
artifacts/extension.zip the extension's zipfile for publishing to Amazon
artifacts/extensions where the contents of the extention will be gathered
artifacts/extensions/honeycomb-lambda-extension the extension's executable
build                compile the extension executable
clean                clean up from builds and tests
publish_aws          publish the extension as a lambda layer to a specified AWS_REGION
test                 run tests with coverage report
zip                  package up the extension in a ZIP file
```

### WIP: fan out lambda-layer publishing in CI?

Kind of neat to make Circle do all the publishing in parallel. Not 100% sure it's _better_.

It takes about 1 minute for the aws-cli orb to spin up and configure itself. Then it takes about 2 minutes total to publish the extension to all listed regions in a loop.

Possible advantages to publishing fan out:

* slightly faster because parallelism?
* look up a region's ARN by looking at the output in the job with a name
  for that region

Possible disadvantages to fan out:

* not _really_ that much faster
* all the resultant ARNs in one job's output makes it easy to scan and
  check that the regions have a consistent layer version at the end
