### PR TITLE
Add debugging mode

### DIFF
--- a/logsapi/server.go
+++ b/logsapi/server.go
@@ -88,6 +88,7 @@ func handler(libhoneyClient *libhoney.Client) http.HandlerFunc {
 				event.Timestamp = parseMessageTimestamp(event, msg)
 				event.Add(msg.Record)
 			}
+			event.Metadata, _ = event.Fields()["name"]
 			event.Send()
 			log.Debug("handler - event enqueued")
 		}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	apiKey  = os.Getenv("LIBHONEY_API_KEY")
 	dataset = os.Getenv("LIBHONEY_DATASET")
 	apiHost = os.Getenv("LIBHONEY_API_HOST")
+	debug = envOrElseBool("HONEYCOMB_DEBUG", false)
 
 	// when run in local mode, we don't attempt to register the extension or subscribe
 	// to log events - useful for testing
@@ -52,7 +53,6 @@ var (
 )
 
 func init() {
-	debug := envOrElseBool("HNY_DEBUG", false)
 	logLevel := logrus.InfoLevel
 	if debug {
 		logLevel = logrus.DebugLevel
@@ -87,7 +87,6 @@ func main() {
 	// initialize libhoney
 	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension/%s", version)
 	client, err := libhoney.NewClient(libhoneyConfig())
-	debug := envOrElseBool("HNY_DEBUG", false)
 	if debug {
 		go readResponses(client.TxResponses())
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- when extension is unable to send events to Honeycomb, users have no way to investigate the issue

## Short description of the changes

- add response queue reader when debugging
- swap the (undocumented) log level for debug for simplicity

