### PR TITLE
fix: amd64 build is called x86_64 in aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ shutdown events.
 ## Usage
 
 To use the honeycomb-lambda-extension with a lambda function, it must be configured as a layer. There are two versions of the extension available:
-- honeycomb-lambda-extension-amd64 (for functions running on `x86_64` architecture)
+- honeycomb-lambda-extension-x86_64 (for functions running on `x86_64` architecture)
 - honeycomb-lambda-extension-arm64 (for functions running on `arm64` architecture)
 
 You can add the extension as a layer with the AWS CLI tool:

--- a/publish.sh
+++ b/publish.sh
@@ -28,12 +28,12 @@ zip -r ext-amd64.zip ext-amd64
 
 for region in ${REGIONS[@]}; do
     RESPONSE=`aws lambda publish-layer-version \
-        --layer-name "$EXTENSION_NAME-amd64" \
-        --compatible-architectures amd64 \
+        --layer-name "$EXTENSION_NAME-x86_64" \
+        --compatible-architectures x86_64 \
         --region $region --zip-file "fileb://ext-amd64.zip"`
     VERSION=`echo $RESPONSE | jq -r '.Version'`
-    aws --region $region lambda add-layer-version-permission --layer-name "$EXTENSION_NAME-amd64" \
-        --version-number $VERSION --statement-id "$EXTENSION_NAME-amd64-$VERSION-$region" \
+    aws --region $region lambda add-layer-version-permission --layer-name "$EXTENSION_NAME-x86_64" \
+        --version-number $VERSION --statement-id "$EXTENSION_NAME-x86_64-$VERSION-$region" \
         --principal "*" --action lambda:GetLayerVersion
 done
 


### PR DESCRIPTION
Renaming the layer version as well for consistency.