### PR TITLE
fix: split publish based on region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To use the honeycomb-lambda-extension with a lambda function, it must be configu
 You can add the extension as a layer with the AWS CLI tool:
 
 ```
-$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:9"
+$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:3"
 ```
 
-- `<ARCH>` --> `amd64` or `arm64`
+- `<ARCH>` --> `x86_64` or `arm64` (*note*: `arm64` is only supported in [certain regions](https://aws.amazon.com/about-aws/whats-new/2021/09/better-price-performance-aws-lambda-functions-aws-graviton2-processor/))
 - `<AWS_REGION>` --> AWS region you want to deploy this in
 
 The extension will attempt to read the following environment variables from your lambda function configuration:
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "extensions-demo-example-lambda-python" {
         }
         
         layers = [
-            "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:9"
+            "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:3"
         ]
 }
 ```

--- a/publish.sh
+++ b/publish.sh
@@ -6,9 +6,9 @@ else
     EXTENSION_NAME="honeycomb-lambda-extension"
 fi
 
-REGIONS=(eu-north-1 ap-south-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1
-         sa-east-1 ca-central-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1
-         us-east-2 us-west-1 us-west-2)
+REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-central-1)
+REGIONS_WITH_ARCH=(ap-south-1 eu-west-2 us-east-1 eu-west-1 ap-northeast-1 ap-southeast-1
+                   ap-southeast-2 eu-central-1 us-east-2 us-west-2)
 
 if [ ! -f ~/artifacts/extensions/honeycomb-lambda-extension-amd64 ]; then
     echo "amd64 extension does not exist, cannot publish."
@@ -26,10 +26,20 @@ mkdir ext-amd64
 cp extensions/honeycomb-lambda-extension-amd64 ext-amd64/
 zip -r ext-amd64.zip ext-amd64
 
-for region in ${REGIONS[@]}; do
+for region in ${REGIONS_WITH_ARCH[@]}; do
     RESPONSE=`aws lambda publish-layer-version \
         --layer-name "$EXTENSION_NAME-x86_64" \
         --compatible-architectures x86_64 \
+        --region $region --zip-file "fileb://ext-amd64.zip"`
+    VERSION=`echo $RESPONSE | jq -r '.Version'`
+    aws --region $region lambda add-layer-version-permission --layer-name "$EXTENSION_NAME-x86_64" \
+        --version-number $VERSION --statement-id "$EXTENSION_NAME-x86_64-$VERSION-$region" \
+        --principal "*" --action lambda:GetLayerVersion
+done
+
+for region in ${REGIONS_NO_ARCH[@]}; do
+    RESPONSE=`aws lambda publish-layer-version \
+        --layer-name "$EXTENSION_NAME-x86_64" \
         --region $region --zip-file "fileb://ext-amd64.zip"`
     VERSION=`echo $RESPONSE | jq -r '.Version'`
     aws --region $region lambda add-layer-version-permission --layer-name "$EXTENSION_NAME-x86_64" \
@@ -41,7 +51,7 @@ mkdir ext-arm64
 cp extensions/honeycomb-lambda-extension-arm64 ext-arm64/
 zip -r ext-arm64.zip ext-arm64
 
-for region in ${REGIONS[@]}; do
+for region in ${REGIONS_WITH_ARCH[@]}; do
     RESPONSE=`aws lambda publish-layer-version \
         --layer-name "$EXTENSION_NAME-arm64" \
         --compatible-architectures arm64 \


### PR DESCRIPTION
- new layer version 3 because name is different

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- aws only supports architecture compatibility in certain regions

## Short description of the changes

- regions with no support: publish x86_64 (no compatible arch flag)
- regions with support: publish both x86_64 and arm64 (with compatible flag)
- update layer version to 3 --> version reset because of layer name change

