### PR TITLE
Prepare for 10.0.1 release (layer version should be 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Honeycomb Lambda Extension Changelog
 
+## 10.0.1 (2021-10-01)
+
+### Fixed
+
+Release 10.0.0 had an issue with the published layer.
+
+- fix: aws publish layer directory name must be extensions (#55)
+- fix: split publish based on region support (#52)
+
 ## 10.0.0 (2021-09-29)
 
-# Added
+### Added
 
 - Support ARM build (#46)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Creating a new release
 
-1. Update `version.go`, add new entry in the changelog. Update readme instructions with the new version. NOTE: layer version and release version are off by one :(
+1. Update `version.go`, add new entry in the changelog. Update readme instructions with the new version. NOTE: layer version and release version just totally different :(
 
 2. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will create a draft GitHub release, and publish the new layer version in AWS.
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	// initialize libhoney
-	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension/%s", version)
+	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension-<arch>/%s", version)
 	client, err := libhoney.NewClient(libhoneyConfig())
 	if debug {
 		go readResponses(client.TxResponses())

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "9"
+const version = "5"


### PR DESCRIPTION
- changed the user-agent to include <arch> because layer version reset with the new layer names
- we don't know arch because it's only known at binary build time
