### PR TITLE
ci: fix s3 sync job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: "Artifacts being published"
           command: |
             echo "about to publish ${CIRCLE_TAG} to S3"
-            ls -l ~/artifacts/extensions/*
+            ls -l ~/artifacts/*
       - run:
           name: "S3 Release"
           command: aws s3 cp ~/artifacts s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/ --recursive


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- removed nested extensions dir in #55 but missed the `ls`

## Short description of the changes

- synced manually last release, which failed sync in CI, so this is just prep for next time we release

