### PR TITLE
Prepare v10.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Honeycomb Lambda Extension Changelog
 
+## 10.0.2 (2021-11-03)
+
+### Maintenance
+
+- bump libhoney-go (#63)
+- empower apply-labels action to apply labels (#62)
+- Bump github.com/honeycombio/libhoney-go from 1.15.4 to 1.15.5 (#53)
+- leave note for future adventurers (#59)
+- ci: fix s3 sync job (#57)
+- docs: update to latest version in readme (#58)
+
 ## 10.0.1 (2021-10-01)
 
 ### Fixed

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "5"
+const version = "10"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "10"
+const version = "6"


### PR DESCRIPTION
## Which problem is this PR solving?
Prepare v10.0.2 release.

## Short description of the changes
- update version.go to "6"
- add entry to changelog

