### PR TITLE
put GOARCH into user agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,14 +8,15 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 
-	libhoney "github.com/honeycombio/libhoney-go"
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/honeycomb-lambda-extension/extension"
 	"github.com/honeycombio/honeycomb-lambda-extension/logsapi"
+	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 )
 
@@ -40,7 +41,7 @@ var (
 	apiKey  = os.Getenv("LIBHONEY_API_KEY")
 	dataset = os.Getenv("LIBHONEY_DATASET")
 	apiHost = os.Getenv("LIBHONEY_API_HOST")
-	debug = envOrElseBool("HONEYCOMB_DEBUG", false)
+	debug   = envOrElseBool("HONEYCOMB_DEBUG", false)
 
 	// when run in local mode, we don't attempt to register the extension or subscribe
 	// to log events - useful for testing
@@ -85,7 +86,7 @@ func main() {
 	}
 
 	// initialize libhoney
-	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension-<arch>/%s", version)
+	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version)
 	client, err := libhoney.NewClient(libhoneyConfig())
 	if debug {
 		go readResponses(client.TxResponses())


### PR DESCRIPTION
## Which problem is this PR solving?

The current libhoney user agent addition includes the literal `<arch>`, eg `libhoney-go/1.15.4 honeycomb-lambda-extension-<arch>/5`. It would be nice to have the actual architecture instead.

## Short description of the changes

`runtime.GOARCH` will be "amd64" or "arm64", which doesn't precisely match the releases using "arm64" and "x86_64", but it's better than nothing, I think?
