### PR TITLE
feat: use msgpack encoding when sending telemetry

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,6 +158,7 @@ func libhoneyConfig() libhoney.ClientConfig {
 		log.Warnln("LIBHONEY_API_KEY or LIBHONEY_DATASET not set, disabling libhoney")
 		return libhoney.ClientConfig{}
 	}
+	userAgent := fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version)
 
 	return libhoney.ClientConfig{
 		APIKey:  apiKey,
@@ -168,7 +169,7 @@ func libhoneyConfig() libhoney.ClientConfig {
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
-			UserAgentAddition:     fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version),
+			UserAgentAddition:     userAgent,
 			EnableMsgpackEncoding: true,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func main() {
 	}
 
 	// initialize libhoney
-	libhoney.UserAgentAddition = fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version)
 	client, err := libhoney.NewClient(libhoneyConfig())
 	if debug {
 		go readResponses(client.TxResponses())
@@ -164,6 +163,14 @@ func libhoneyConfig() libhoney.ClientConfig {
 		APIKey:  apiKey,
 		Dataset: dataset,
 		APIHost: apiHost,
+		Transmission: &transmission.Honeycomb{
+			MaxBatchSize:          libhoney.DefaultMaxBatchSize,
+			BatchTimeout:          libhoney.DefaultBatchTimeout,
+			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
+			PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
+			UserAgentAddition:     fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version),
+			EnableMsgpackEncoding: true,
+		},
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- the extension is currently using a less efficient transport encoding
- closes #67 

## Short description of the changes

- configure libhoney client to use msgpack

