### PR TITLE
feat: add shutdown reason event for timeouts and failures

### DIFF
--- a/eventprocessor/eventprocessor.go
+++ b/eventprocessor/eventprocessor.go
@@ -1,0 +1,107 @@
+package eventprocessor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/honeycombio/honeycomb-lambda-extension/extension"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	log = logrus.WithFields(logrus.Fields{
+		"source": "hny-lambda-ext-eventprocessor",
+	})
+	// ShutdownReasonFieldExtensionType is the field name for shutdown reason in shutdown reason event
+	ShutdownReasonFieldExtensionType = "lambda_extension.type"
+	// ShutdownReasonFieldRequestID is the field name used for request ID in shutdown reason event
+	ShutdownReasonFieldRequestID = "requestId"
+	// ShutdownReasonFieldInvokedFunctionARN is the field name used for function arn in shutdown reason event
+	ShutdownReasonFieldInvokedFunctionARN = "invokedFunctionArn"
+)
+
+// eventPoller is the interface that provides a next event for the event processor
+type eventPoller interface {
+	NextEvent(ctx context.Context) (*extension.NextEventResponse, error)
+}
+
+// eventFlusher is the interface that provides a way to create new libhoney events and flush them
+type eventFlusher interface {
+	NewEvent() *libhoney.Event
+	Flush()
+}
+
+// Server represents a server that polls and processes Lambda extension events
+type Server struct {
+	extensionClient    eventPoller
+	libhoneyClient     eventFlusher
+	invokedFunctionARN string
+	lastRequestId      string
+}
+
+// New takes an eventPoller and eventFlusher and returns a Server
+func New(extensionClient eventPoller, libhoneyClient eventFlusher) *Server {
+	return &Server{
+		extensionClient: extensionClient,
+		libhoneyClient:  libhoneyClient,
+	}
+}
+
+// Run executes an event loop to poll and process events from the Lambda extension API
+func (s *Server) Run(ctx context.Context, cancel context.CancelFunc) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			s.pollEventAndProcess(ctx, cancel)
+		}
+	}
+}
+
+// pollEventAndProcess polls the Lambda extension next event API and processes a single event
+func (s *Server) pollEventAndProcess(ctx context.Context, cancel context.CancelFunc) {
+	// Poll for event
+	res, err := s.extensionClient.NextEvent(ctx)
+	if err != nil {
+		log.WithError(err).Warn("Error from NextEvent")
+		return
+	}
+
+	// Ensure a flush happens and cancel is called if its a shutdown event
+	defer func() {
+		s.libhoneyClient.Flush()
+		if res.EventType == extension.Shutdown {
+			cancel()
+		}
+	}()
+
+	// Handles event types
+	switch eventType := res.EventType; eventType {
+	case extension.Invoke:
+		log.Debug("Received INVOKE event.")
+		s.lastRequestId = res.RequestID
+		s.invokedFunctionARN = res.InvokedFunctionARN
+	case extension.Shutdown:
+		log.Debug("Received SHUTDOWN event.")
+		if res.ShutdownReason != extension.ShutdownReasonSpindown && s.lastRequestId != "" {
+			log.WithField("res.ShutdownReason", res.ShutdownReason).Debug("Sending shutdown reason")
+			s.sendShutdownReason(res.ShutdownReason)
+		}
+	default:
+		log.WithField("res", res).Debug("Received unknown event")
+	}
+}
+
+// sendShutdownReason sends and flushes an event with the shutdown reason. The last
+// request ID and function ARN will also be include in the generated event.
+func (s *Server) sendShutdownReason(shutdownReason extension.ShutdownReason) {
+	ev := s.libhoneyClient.NewEvent()
+	ev.AddField(ShutdownReasonFieldExtensionType, fmt.Sprintf("platform.%s", shutdownReason))
+	ev.AddField(ShutdownReasonFieldRequestID, s.lastRequestId)
+	ev.AddField(ShutdownReasonFieldInvokedFunctionARN, s.invokedFunctionARN)
+	if err := ev.Send(); err != nil {
+		log.WithError(err).Error("Unable to send event with shutdown reason")
+	}
+}

--- a/eventprocessor/eventprocessor_test.go
+++ b/eventprocessor/eventprocessor_test.go
@@ -1,0 +1,202 @@
+package eventprocessor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/honeycombio/honeycomb-lambda-extension/eventprocessor"
+	"github.com/honeycombio/honeycomb-lambda-extension/extension"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	tests := map[string]struct {
+		eventPoller            *fakeEventPoller
+		eventFlusher           *fakeEventFlusher
+		expectedNextEventCount int
+		expectedFlushCount     int
+		expectedShutdownEvent  *transmission.Event
+	}{
+		"a single invoke event type and normal shutdown": {
+			eventPoller: &fakeEventPoller{nextEventResponses: []*extension.NextEventResponse{
+				{
+					EventType:          extension.Invoke,
+					RequestID:          "1",
+					InvokedFunctionARN: "arn1",
+				},
+				{
+					EventType:      extension.Shutdown,
+					ShutdownReason: extension.ShutdownReasonSpindown,
+				},
+			}},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 2,
+			expectedFlushCount:     2,
+			expectedShutdownEvent:  nil,
+		},
+		"a single invoke event type and failure shutdown": {
+			eventPoller: &fakeEventPoller{nextEventResponses: []*extension.NextEventResponse{
+				{
+					EventType:          extension.Invoke,
+					RequestID:          "1",
+					InvokedFunctionARN: "arn1",
+				},
+				{
+					EventType:      extension.Shutdown,
+					ShutdownReason: extension.ShutdownReasonFailure,
+				},
+			}},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 2,
+			expectedFlushCount:     2,
+			expectedShutdownEvent: &transmission.Event{
+				Data: map[string]interface{}{
+					eventprocessor.ShutdownReasonFieldExtensionType:      "platform.failure",
+					eventprocessor.ShutdownReasonFieldRequestID:          "1",
+					eventprocessor.ShutdownReasonFieldInvokedFunctionARN: "arn1",
+				},
+			},
+		},
+		"a single invoke event type and timeout shutdown": {
+			eventPoller: &fakeEventPoller{nextEventResponses: []*extension.NextEventResponse{
+				{
+					EventType:          extension.Invoke,
+					RequestID:          "1",
+					InvokedFunctionARN: "arn1",
+				},
+				{
+					EventType:      extension.Shutdown,
+					ShutdownReason: extension.ShutdownReasonTimeout,
+				},
+			}},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 2,
+			expectedFlushCount:     2,
+			expectedShutdownEvent: &transmission.Event{
+				Data: map[string]interface{}{
+					eventprocessor.ShutdownReasonFieldExtensionType:      "platform.timeout",
+					eventprocessor.ShutdownReasonFieldRequestID:          "1",
+					eventprocessor.ShutdownReasonFieldInvokedFunctionARN: "arn1",
+				},
+			},
+		},
+		"a timeout shutdown (no last requestId)": {
+			eventPoller: &fakeEventPoller{nextEventResponses: []*extension.NextEventResponse{
+				{
+					EventType:      extension.Shutdown,
+					ShutdownReason: extension.ShutdownReasonTimeout,
+				},
+			}},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 1,
+			expectedFlushCount:     1,
+			expectedShutdownEvent:  nil,
+		},
+		"a single next event error, then normal invoke event type and normal shutdown": {
+			eventPoller: &fakeEventPoller{
+				oneTimeError: errors.New("one time error"),
+				nextEventResponses: []*extension.NextEventResponse{
+					{
+						EventType:          extension.Invoke,
+						RequestID:          "1",
+						InvokedFunctionARN: "arn1",
+					},
+					{
+						EventType:      extension.Shutdown,
+						ShutdownReason: extension.ShutdownReasonSpindown,
+					},
+				},
+			},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 2,
+			expectedFlushCount:     2,
+			expectedShutdownEvent:  nil,
+		},
+		"an unknown event type and normal shutdown": {
+			eventPoller: &fakeEventPoller{
+				nextEventResponses: []*extension.NextEventResponse{
+					{
+						EventType: "unknown",
+					},
+					{
+						EventType:      extension.Shutdown,
+						ShutdownReason: extension.ShutdownReasonSpindown,
+					},
+				},
+			},
+			eventFlusher:           newFakeEventFlusher(),
+			expectedNextEventCount: 2,
+			expectedFlushCount:     2,
+			expectedShutdownEvent:  nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			processor := eventprocessor.New(tc.eventPoller, tc.eventFlusher)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			processor.Run(ctx, cancel)
+
+			assert.Equal(t, tc.expectedNextEventCount, tc.eventPoller.nextEventCounter, "next event calls do not match")
+			assert.Equal(t, tc.expectedFlushCount, tc.eventFlusher.mockSender.Flushed, "flush calls do not match")
+			if tc.expectedShutdownEvent != nil {
+				assert.Equal(t, tc.expectedShutdownEvent.Data, tc.eventFlusher.mockSender.Events()[0].Data, "shutdown event does not match")
+			}
+		})
+	}
+}
+
+// ###########################################
+// Test implementations
+// ###########################################
+
+type fakeEventPoller struct {
+	oneTimeError       error
+	nextEventCounter   int
+	nextEventResponses []*extension.NextEventResponse
+}
+
+func (f *fakeEventPoller) NextEvent(ctx context.Context) (*extension.NextEventResponse, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if f.oneTimeError != nil {
+		err := f.oneTimeError
+		f.oneTimeError = nil
+		return nil, err
+	}
+	resp := f.nextEventResponses[f.nextEventCounter]
+	f.nextEventCounter++
+	return resp, nil
+}
+
+func newFakeEventFlusher() *fakeEventFlusher {
+	mockSender := &transmission.MockSender{}
+	libhoneyClient, _ := libhoney.NewClient(libhoney.ClientConfig{
+		APIKey:       "unit-test-api-key",
+		Dataset:      "unit-test-dataset",
+		Transmission: mockSender,
+	})
+	return &fakeEventFlusher{
+		mockSender:     mockSender,
+		libhoneyClient: libhoneyClient,
+	}
+}
+
+type fakeEventFlusher struct {
+	libhoneyClient *libhoney.Client
+	mockSender     *transmission.MockSender
+}
+
+func (f *fakeEventFlusher) NewEvent() *libhoney.Event {
+	return f.libhoneyClient.NewEvent()
+}
+
+func (f *fakeEventFlusher) Flush() {
+	f.mockSender.Flush()
+}

--- a/extension/client.go
+++ b/extension/client.go
@@ -17,12 +17,20 @@ import (
 // EventType represents the type of events received from /event/next
 type EventType string
 
+// ShutdownReason represents the reason for a shutdown event
+type ShutdownReason string
+
 const (
 	// Invoke is the lambda invoke event
 	Invoke EventType = "INVOKE"
 	// Shutdown is a shutdown event for the environment
 	Shutdown EventType = "SHUTDOWN"
-
+	// ShutdownReasonSpindown is a normal end to a function
+	ShutdownReasonSpindown ShutdownReason = "spindown"
+	// ShutdownReasonTimeout means the handler ran out of time
+	ShutdownReasonTimeout ShutdownReason = "timeout"
+	// ShutdownReasonFailure is any other shutdown type, such as out-of-memory
+	ShutdownReasonFailure ShutdownReason = "failure"
 	// extensionNameHeader identifies the extension when registering
 	extensionNameHeader = "Lambda-Extension-Name"
 	// extensionIdentifierHeader is a uuid that is required on subsequent requests
@@ -60,11 +68,12 @@ type Tracing struct {
 
 // NextEventResponse is the response for /event/next
 type NextEventResponse struct {
-	EventType          EventType `json:"eventType"`
-	DeadlineMS         int64     `json:"deadlineMs"`
-	RequestID          string    `json:"requestId"`
-	InvokedFunctionARN string    `json:"invokedFunctionArn"`
-	Tracing            Tracing   `json:"tracing"`
+	EventType          EventType      `json:"eventType"`
+	DeadlineMS         int64          `json:"deadlineMs"`
+	RequestID          string         `json:"requestId"`
+	InvokedFunctionARN string         `json:"invokedFunctionArn"`
+	Tracing            Tracing        `json:"tracing"`
+	ShutdownReason     ShutdownReason `json:"shutdownReason,omitempty"`
 }
 
 // NewClient returns a new Lambda Extensions API client


### PR DESCRIPTION
## Which problem is this PR solving?
This PR adds an additional shutdown reason event that is emitted on abnormal Lambda shutdowns. This provides a way to identify when a Lambda function execution timed out or had some type of failure like an out of memory condition. 

<img width="1056" alt="shutdown-event-example" src="https://user-images.githubusercontent.com/84951447/156811690-c9b675ea-bb2b-4c8f-9096-c69172232ed6.png">


## Short description of the changes
* For any abnormal Lambda shutdown, this change emits an additional event that includes the shutdown reason, request id, and function ARN. The shutdown phase of the Lambda extension API (https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html) provides a 'shutdownReason' that is set to `spindown`/`timeout`/`failure`, and this PR uses that information to create the event. 
* It was difficult to write tests with everything in main, so the primary event loop was relocated to a new package, and unit tests were written for it there.

