### PR TITLE
maint: add go 1.18 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.0
+  go: circleci/go@1.7.1
   aws-cli: circleci/aws-cli@2.0.3
 
 jobs:
@@ -9,7 +9,7 @@ jobs:
     parameters:
       goversion:
         type: "string"
-        default: "1.16"
+        default: "1.18"
     executor:
       name: go/default
       tag: << parameters.goversion >>
@@ -31,7 +31,7 @@ jobs:
         default: "amd64"
     executor:
       name: go/default
-      tag: "1.16"
+      tag: "1.18"
     steps:
       - checkout
       - go/load-cache
@@ -54,7 +54,7 @@ jobs:
           path: ~/artifacts
   publish_aws:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.18
     steps:
       - attach_workspace:
           at: ~/
@@ -83,7 +83,7 @@ jobs:
           command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts/
   publish_s3:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.18
     steps:
       - attach_workspace:
           at: ~/
@@ -119,6 +119,7 @@ workflows:
                 - "1.15"
                 - "1.16"
                 - "1.17"
+                - "1.18"
 
   build:
     jobs:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- go 1.18 was released earlier this month

## Short description of the changes

- add to 1.18 to test matrix
- update default go version to 1.18
- bump go orb

