### PR TITLE
maint: update readme to reflect lambda layer 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use the honeycomb-lambda-extension with a lambda function, it must be configu
 You can add the extension as a layer with the AWS CLI tool:
 
 ```
-$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:7"
+$ aws lambda update-code-configuration --function-name MyLambdaFunction --layers "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:9"
 ```
 
 - `<ARCH>` --> `x86_64` or `arm64` (*note*: `arm64` is only supported in [certain regions](https://aws.amazon.com/about-aws/whats-new/2021/09/better-price-performance-aws-lambda-functions-aws-graviton2-processor/))
@@ -52,9 +52,9 @@ resource "aws_lambda_function" "extensions-demo-example-lambda-python" {
                         LIBHONEY_API_HOST = "api.honeycomb.io"
                 }
         }
-        
+
         layers = [
-            "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:7"
+            "arn:aws:lambda:<AWS_REGION>:702835727665:layer:honeycomb-lambda-extension-<ARCH>:9"
         ]
 }
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [release 10.2.0](https://github.com/honeycombio/honeycomb-lambda-extension/pull/80) updated the lambda version to 9, but our readme still reflects 7 .

## Short description of the changes

- update readme to reflect lambda layer 9

