### PR TITLE
maint: update releasing notes, be explicit about layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Honeycomb Lambda Extension Changelog
 
-## 10.2.0 (2002-04-08)
+## [v10.2.0] Layer 9 - 2022-04-08
 
 ### Added
 
@@ -12,7 +12,7 @@
 - Bump github.com/stretchr/testify from 1.7.0 to 1.7.1 (#78)
 - Bump github.com/honeycombio/libhoney-go from 1.15.6 to 1.15.8 (#74)
 
-## 10.1.0 (2022-01-07)
+## [v10.1.0] Layer 8 - 2022-01-07
 
 ### Added
 
@@ -23,13 +23,13 @@
 - ci: Add re-triage workflow (#71) | [@vreynolds](https://github.com/vreynolds)
 - docs: update layer version (#70) | [@vreynolds](https://github.com/vreynolds)
 
-## 10.0.3 (2021-11-18)
+## [v10.0.3] Layer 7 - 2021-11-18
 
 ### Maintenance
 
 - Put GOARCH into user agent (#65) | [@dstrelau](https://github.com/dstrelau)
 
-## 10.0.2 (2021-11-03)
+## [v10.0.2] Layer 6 - 2021-11-03
 
 ### Maintenance
 
@@ -40,7 +40,7 @@
 - ci: fix s3 sync job (#57)
 - docs: update to latest version in readme (#58)
 
-## 10.0.1 (2021-10-01)
+## [v10.0.1] Layer 5 - 2021-10-01
 
 ### Fixed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
 1. Add new entry in `CHANGELOG.md`, include both release version and layer version.
 1. Open a PR for release prep.
 1. Once the above changes are merged into `main`, tag `main` with the new release version, e.g. `v0.1.1`. Push the tag. This will kick off CI, which will create a draft GitHub release and publish the new layer version in AWS.
-1. Update release notes on the new draft GitHub release, and publish that.
+1. Update release notes on the new draft GitHub release with notes from changelog and Layer Version ARN, and publish that.
 1. Merge PR in public docs with the new version.
 
 Voila!

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,12 @@
 # Creating a new release
 
-1. Update `version.go`, add new entry in the changelog. Update readme instructions with the new version. NOTE: layer version and release version are totally different :(
-
-2. Once the above changes are merged into `main`, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off CI, which will create a draft GitHub release, and publish the new layer version in AWS.
-
-3. Update release notes on the new draft GitHub release, and publish that.
-
-4. Update public docs and repo README with the new layer version.
+1. Prep docs PR for updated layer version and release version. **NOTE**: layer version and release version are totally different :(
+1. Update `version.go` with new layer version.
+1. Update `README.md` with new layer version.
+1. Add new entry in `CHANGELOG.md`, include both release version and layer version.
+1. Open a PR for release prep.
+1. Once the above changes are merged into `main`, tag `main` with the new release version, e.g. `v0.1.1`. Push the tag. This will kick off CI, which will create a draft GitHub release and publish the new layer version in AWS.
+1. Update release notes on the new draft GitHub release, and publish that.
+1. Merge PR in public docs with the new version.
 
 Voila!


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- honeycomb-lambda-extension is funky with different versions and different places to update.

## Short description of the changes

- update `CHANGELOG.md` to be explicit about which layers go with which versions
- update `RELEASING.md` to make steps more clear

