### PR TITLE
add missing default regions

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -8,7 +8,8 @@ else
     EXTENSION_NAME="honeycomb-lambda-extension"
 fi
 
-REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-central-1 af-south-1 ap-east-1 eu-south-1 me-south-1)
+REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-central-1 af-south-1
+                ap-east-1 eu-south-1 me-south-1 ap-southeast-3 ap-northeast-3)
 REGIONS_WITH_ARCH=(ap-south-1 eu-west-2 us-east-1 eu-west-1 ap-northeast-1 ap-southeast-1
                    ap-southeast-2 eu-central-1 us-east-2 us-west-2)
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #91 

## Short description of the changes

- Add ap-southeast-3 and ap-northeast-3 to list of regions to publish. Note they are added to `REGIONS_NO_ARCH` as they only support x86_64 and not arm64.
