### PR TITLE
(no changelog): only warn about invalid TIMEOUT env var if it is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,8 +227,8 @@ func envOrElseDuration(key string, fallback time.Duration) time.Duration {
 			log.Warnf("%s was set to %d (an integer, not a duration). Assuming 'seconds' as unit, resulting in %s.", key, v, dur_s)
 			return dur_s
 		}
+		log.Warnf("%s was set to '%s', but failed to parse to a duration. Falling back to default of %s.", key, value, fallback)
 	}
-	log.Warnf("%s was set to '%s', but failed to parse to a duration. Falling back to default of %s.", key, value, fallback)
 	return fallback
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Follow up to #98

## Short description of the changes

- We were warning if when the env var was not set. Stop doing that by moving the warn inside the if-statement checking for variable existence.

