### PR TITLE
maint: release process updates for friendlier ARNs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,12 @@ jobs:
       - go/mod-download
       - go/save-cache
       - run:
-          name: "Build Binaries"
+          name: "Build binaries and layer content ZIPs"
           environment:
             GOOS: linux
-          command: make build
+          command: make zips
       - run:
-          name: "Copy binaries to persist for CI workspace"
+          name: "Copy binaries and ZIPs to persist for CI workspace"
           command: |
             mkdir -p ~/artifacts
             cp -R ./artifacts/* ~/artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,10 @@ jobs:
       - checkout
       - go/load-cache
       - go/mod-download
+      - run: make test
+      - store_test_results:
+          path: ./unit-tests.xml
       - go/save-cache
-      - go/test:
-          covermode: atomic
-          failfast: true
-          race: true
   build_extension:
     parameters:
       arch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: |
             echo "Building extension"
             mkdir ~/artifacts
-            go build -o ~/artifacts/honeycomb-lambda-extension-<< parameters.arch >> .
+            go build -ldflags "-X main.version=${CIRCLE_TAG}" -o ~/artifacts/honeycomb-lambda-extension-<< parameters.arch >> .
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,6 @@ jobs:
           path: ./unit-tests.xml
       - go/save-cache
   build_extension:
-    parameters:
-      arch:
-        description: Target architecture
-        type: enum
-        enum: ["amd64", "arm64"]
-        default: "amd64"
     executor:
       name: go/default
       tag: *goversion
@@ -36,14 +30,15 @@ jobs:
       - go/mod-download
       - go/save-cache
       - run:
-          name: "Build Binary"
+          name: "Build Binaries"
           environment:
             GOOS: linux
-            GOARCH: << parameters.arch >>
+          command: make build
+      - run:
+          name: "Copy binaries to persist for CI workspace"
           command: |
-            echo "Building extension"
-            mkdir ~/artifacts
-            go build -ldflags "-X main.version=${CIRCLE_TAG}" -o ~/artifacts/honeycomb-lambda-extension-<< parameters.arch >> .
+            mkdir -p ~/artifacts
+            cp -R ./artifacts/* ~/artifacts/
       - persist_to_workspace:
           root: ~/
           paths:
@@ -126,11 +121,6 @@ workflows:
               ignore:
                 - /pull\/.*/
                 - /dependabot\/.*/
-          matrix:
-            parameters:
-              arch:
-                - "amd64"
-                - "arm64"
       - publish_s3:
           context: Honeycomb Secrets for Public Repos
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,23 +4,14 @@ orbs:
   go: circleci/go@1.7.1
   aws-cli: circleci/aws-cli@2.0.3
 
-# Default version of Go to use for Go steps
-default_goversion: &default_goversion "1.19"
-
-matrix_goversions: &matrix_goversions
-  matrix:
-    parameters:
-      goversion: ["1.17", "1.18", "1.19"]
+# The Go we test and build against
+goversion: &goversion "1.19"
 
 jobs:
   test:
-    parameters:
-      goversion:
-        type: "string"
-        default: *default_goversion
     executor:
       name: go/default
-      tag: << parameters.goversion >>
+      tag: *goversion
     steps:
       - checkout
       - go/load-cache
@@ -39,7 +30,7 @@ jobs:
         default: "amd64"
     executor:
       name: go/default
-      tag: *default_goversion
+      tag: *goversion
     steps:
       - checkout
       - go/load-cache
@@ -119,13 +110,11 @@ workflows:
               only:
                 - main
     jobs:
-      - test: &test
-          <<: *matrix_goversions
+      - test
 
   build:
     jobs:
       - test:
-          <<: *test
           filters:
             tags:
               only: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+unit-tests.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+artifacts/
 unit-tests.xml

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,15 @@
 # Example: GOOS=darwin make build
 GOOS ?= linux
 
+# CIRCLE_TAG is generally not set unless CircleCI is running a workflow
+# triggered by a git tag creation.
+# If set, the value will be used for the version of the build.
+# If unset, determine a reasonable version identifier for current current commit
+# based on the closest vX.Y.Z tag in the branch's history. For example: v10.4.0-6-ged57c1e
+# --tags :: consider all tags, not only annotated tags
+# --match :: a regex to select a tag that matches our version number tag scheme
+CIRCLE_TAG ?= $(shell git describe --always --tags --match "v[0-9]*" HEAD)
+
 layer_name_root = honeycomb-lambda-extension
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ zips:
 endif
 
 .PHONY: publish-sandbox
+# Ex: AWS_ARCH=arm64 AWS_REGION=us-east-1 make publish_sandbox
+#
 #: for serious, don't use this as-is for real publishing
 publish_sandbox: are_you_sure arch_required region_required zips
 	@echo "\n*** Publishing honeycomb-lambda-extension-${AWS_ARCH} to ${AWS_REGION}"
@@ -123,5 +125,5 @@ check_defined = \
 		$(call __check_defined,$1,$(strip $(value 2)))))
 __check_defined = \
 	$(if $(value $1),, \
-		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
+		$(error Unset environment variable $1$(if $2, ($2))$(if $(value @), \
 			required by target `$@')))

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ GOOS ?= linux
 CIRCLE_TAG ?= $(shell git describe --always --tags --match "v[0-9]*" HEAD)
 
 .PHONY: test
+#: run the tests!
 test:
 ifeq (, $(shell which gotestsum))
 	@echo " ***"
@@ -53,9 +54,13 @@ build: $(BUILD_DIR)/honeycomb-lambda-extension-arm64 $(BUILD_DIR)/honeycomb-lamb
 #
 # Linux is the only supported OS.
 #
-# some of the Make automatica variables in use in these recipes:
-#   $(@D) - the directory portion of the target, e.g. foo/bar/baz/buzz.zip, $(@D) == foo/bar/baz
-#   $(@F) - the file portion of the target, e.g. foo/bar/baz/buzz.zip, $(@F) == buzz.zip
+# The ZIP file for the content of a lambda layers a.k.a. extention MUST have:
+#   * an extensions/ directory
+#   * the executable that is the extension located within the extensions/ directory
+#
+# some of the Make automatic variables in use in these recipes:
+#   $(@D) - the directory portion of the target, e.g. artifacts/linux/thingie.zip $(@D) == artifacts/linux
+#   $(@F) - the file portion of the target, e.g. artifacts/linux/thingie.zip, $(@F) == thingie.zip
 #   $<    - the first prerequisite, in this case the executable being put into the zip file
 $(ARTIFACT_DIR)/linux/extension-arm64.zip: $(ARTIFACT_DIR)/linux/honeycomb-lambda-extension-arm64
 	@echo "\n*** Packaging honeycomb-lambda-extension for linux into layer contents zipfile"

--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,12 @@ arch_required:
 
 .PHONY: are_you_sure
 are_you_sure:
-		@( read -p "Are you sure?!? [y/N]: " sure && case "$$sure" in [yY]) true;; *) false;; esac )
+	@( read -p "Are you sure?!? [y/N]: " sure && case "$$sure" in [yY]) true;; *) false;; esac )
 
 check_defined = \
-    $(strip $(foreach 1,$1, \
-        $(call __check_defined,$1,$(strip $(value 2)))))
+	$(strip $(foreach 1,$1, \
+		$(call __check_defined,$1,$(strip $(value 2)))))
 __check_defined = \
-    $(if $(value $1),, \
-        $(error Undefined $1$(if $2, ($2))$(if $(value @), \
-                required by target `$@')))
+	$(if $(value $1),, \
+		$(error Undefined $1$(if $2, ($2))$(if $(value @), \
+			required by target `$@')))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 GOOS=linux
 GOARCH=amd64
 
+.PHONY: test
+test:
+ifeq (, $(shell which gotestsum))
+	@echo " ***"
+	@echo "Running with standard go test because gotestsum was not found on PATH. Consider installing gotestsum for friendlier test output!"
+	@echo " ***"
+	go test -race ./...
+else
+	gotestsum --junitfile unit-tests.xml --format testname -- -race ./...
+endif
+
 build:
 	mkdir -p bin/extensions
 	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/extensions/honeycomb-lambda-extension .

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ else
 	gotestsum --junitfile unit-tests.xml --format testname -- -race ./...
 endif
 
+.PHONY: version
+version:
+	@echo $(CIRCLE_TAG)
+
 # target directory for artifact builds
 ARTIFACT_DIR := artifacts
 $(ARTIFACT_DIR):

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-GOOS=linux
-GOARCH=amd64
+# Which operating system to target for a Go build?
+# Defaults to linux because the extension runs in a linux compute environment.
+# Override in development if you wish to build and run on your dev host.
+# Example: GOOS=darwin make build
+GOOS ?= linux
+
+layer_name_root = honeycomb-lambda-extension
 
 .PHONY: test
 test:
@@ -13,8 +18,13 @@ else
 endif
 
 build:
-	mkdir -p bin/extensions
-	GOOS=${GOOS} GOARCH=${GOARCH} go build -o bin/extensions/honeycomb-lambda-extension .
+	@echo "\n*** Building ${layer_name_root} binaries for ${GOOS}"
+	mkdir -p artifacts
+	GOARCH=amd64 go build -ldflags "-X main.version=${CIRCLE_TAG}" -o artifacts/${layer_name_root}-x86_64 .
+	GOARCH=arm64 go build -ldflags "-X main.version=${CIRCLE_TAG}" -o artifacts/${layer_name_root}-arm64 .
 
 publish: build
 	cd bin && zip -r extension.zip extensions && aws lambda publish-layer-version --layer-name honeycomb-lambda-extension --region us-east-1 --zip-file "fileb://extension.zip"
+
+clean:
+	rm -rf artifacts

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ const (
 )
 
 var (
+	version string // Fed in at build with -ldflags "-X main.version=<value>"
+
 	// This environment variable is set in the extension environment. It's expected to be
 	// a hostname:port combination.
 	runtimeAPI = os.Getenv("AWS_LAMBDA_RUNTIME_API")
@@ -63,6 +65,10 @@ var (
 )
 
 func init() {
+	if version == "" {
+		version = "dev"
+	}
+
 	logLevel := logrus.InfoLevel
 	if debug {
 		logLevel = logrus.DebugLevel
@@ -157,7 +163,7 @@ func libhoneyConfig() libhoney.ClientConfig {
 func newTransmission() *transmission.Honeycomb {
 	batchSendTimeout := envOrElseDuration("HONEYCOMB_BATCH_SEND_TIMEOUT", defaultBatchSendTimeout)
 
-	userAgent := fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version)
+	userAgent := fmt.Sprintf("honeycomb-lambda-extension/%s (%s)", version, runtime.GOARCH)
 
 	return &transmission.Honeycomb{
 		MaxBatchSize:          libhoney.DefaultMaxBatchSize,

--- a/publish.sh
+++ b/publish.sh
@@ -20,7 +20,7 @@ EXTENSION_NAME="honeycomb-lambda-extension"
 # Region list update from AWS Lambda pricing page as of 2022/10/12
 #
 # regions with x86_64 only support
-# REGIONS_NO_ARCH=(me-central-1) # listed on pricing page, but we need grant our publishing credentials permission to publish there first
+# REGIONS_NO_ARCH=(me-central-1) # listed on pricing page, but we need enable this region before publishing to it.
 REGIONS_NO_ARCH=()
 # Regions with x86_64 & arm64
 REGIONS_WITH_ARCH=(

--- a/publish.sh
+++ b/publish.sh
@@ -26,29 +26,46 @@ REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-cent
 REGIONS_WITH_ARCH=(ap-south-1 eu-west-2 us-east-1 eu-west-1 ap-northeast-1 ap-southeast-1
                    ap-southeast-2 eu-central-1 us-east-2 us-west-2)
 
+results_dir="publishing"
+mkdir -p ${results_dir}
+
 ### x86_64 ###
 
 layer_name_x86_64="${EXTENSION_NAME}-x86_64-${VERSION}"
 
 for region in ${REGIONS_WITH_ARCH[@]}; do
-    RESPONSE=`aws lambda publish-layer-version \
+    id="x86_64-${region}"
+    publish_results_json="${results_dir}/publish-${id}.json"
+    permit_results_json="${results_dir}/permit-${id}.json"
+    aws lambda publish-layer-version \
         --layer-name $layer_name_x86_64 \
         --compatible-architectures x86_64 \
-        --region $region --zip-file "fileb://${artifact_dir}/extension-x86_64.zip"`
-    layer_version=`echo $RESPONSE | jq -r '.Version'`
+        --region $region \
+        --zip-file "fileb://${artifact_dir}/extension-x86_64.zip" \
+        --no-cli-pager \
+        > "${publish_results_json}"
+    layer_version=`jq -r '.Version' ${publish_results_json}`
     aws --region $region lambda add-layer-version-permission --layer-name $layer_name_x86_64 \
         --version-number $layer_version --statement-id "$EXTENSION_NAME-x86_64-$layer_version-$region" \
-        --principal "*" --action lambda:GetLayerVersion
+        --principal "*" --action lambda:GetLayerVersion --no-cli-pager \
+        > "${permit_results_json}"
 done
 
 for region in ${REGIONS_NO_ARCH[@]}; do
-    RESPONSE=`aws lambda publish-layer-version \
+    id="x86_64-${region}"
+    publish_results_json="${results_dir}/publish-${id}.json"
+    permit_results_json="${results_dir}/permit-${id}.json"
+    aws lambda publish-layer-version \
         --layer-name $layer_name_x86_64 \
-        --region $region --zip-file "fileb://${artifact_dir}/extension-x86_64.zip"`
-    layer_version=`echo $RESPONSE | jq -r '.Version'`
+        --region $region \
+        --zip-file "fileb://${artifact_dir}/extension-x86_64.zip" \
+        --no-cli-pager \
+        > "${publish_results_json}"
+    layer_version=`jq -r '.Version' ${publish_results_json}`
     aws --region $region lambda add-layer-version-permission --layer-name $layer_name_x86_64 \
         --version-number $layer_version --statement-id "$EXTENSION_NAME-x86_64-$layer_version-$region" \
-        --principal "*" --action lambda:GetLayerVersion
+        --principal "*" --action lambda:GetLayerVersion --no-cli-pager \
+        > "${permit_results_json}"
 done
 
 ### arm64 ###
@@ -56,12 +73,19 @@ done
 layer_name_arm64="${EXTENSION_NAME}-arm64-${VERSION}"
 
 for region in ${REGIONS_WITH_ARCH[@]}; do
-    RESPONSE=`aws lambda publish-layer-version \
+    id="arm64-${region}"
+    publish_results_json="${results_dir}/publish-${id}.json"
+    permit_results_json="${results_dir}/permit-${id}.json"
+    aws lambda publish-layer-version \
         --layer-name $layer_name_arm64 \
         --compatible-architectures arm64 \
-        --region $region --zip-file "fileb://${artifact_dir}/extension-arm64.zip"`
-    layer_version=`echo $RESPONSE | jq -r '.Version'`
+        --region $region \
+        --zip-file "fileb://${artifact_dir}/extension-arm64.zip" \
+        --no-cli-pager \
+        > "${publish_results_json}"
+    layer_version=`jq -r '.Version' ${publish_results_json}`
     aws --region $region lambda add-layer-version-permission --layer-name $layer_name_arm64 \
         --version-number $layer_version --statement-id "$EXTENSION_NAME-arm64-$layer_version-$region" \
-        --principal "*" --action lambda:GetLayerVersion
+        --principal "*" --action lambda:GetLayerVersion --no-cli-pager \
+        > "${permit_results_json}"
 done

--- a/publish.sh
+++ b/publish.sh
@@ -116,3 +116,11 @@ for region in ${REGIONS_WITH_ARCH[@]}; do
         --principal "*" --action lambda:GetLayerVersion --no-cli-pager \
         > "${permit_results_json}"
 done
+
+echo ""
+echo "Published Layer Versions:"
+echo ""
+jq '{ region: (.LayerArn | split(":")[3]),
+        arch: (.LayerArn | split(":")[6] | split("-")[3]),
+        arn: .LayerVersionArn
+    }' publishing/publish-*.json

--- a/publish.sh
+++ b/publish.sh
@@ -15,11 +15,7 @@ VERSION="${CIRCLE_TAG:-$(make version)}"
 # turn periods into dashes and cry into your coffee
 VERSION=$(echo ${VERSION} | tr '.' '-')
 
-if [[ "${VERSION}" == *dev ]]; then
-    EXTENSION_NAME="honeycomb-lambda-extension-dev"
-else
-    EXTENSION_NAME="honeycomb-lambda-extension"
-fi
+EXTENSION_NAME="honeycomb-lambda-extension"
 
 # Region list update from AWS Lambda pricing page as of 2022/10/12
 #

--- a/publish.sh
+++ b/publish.sh
@@ -13,8 +13,8 @@ REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-cent
 REGIONS_WITH_ARCH=(ap-south-1 eu-west-2 us-east-1 eu-west-1 ap-northeast-1 ap-southeast-1
                    ap-southeast-2 eu-central-1 us-east-2 us-west-2)
 
-if [ ! -f ~/artifacts/honeycomb-lambda-extension-amd64 ]; then
-    echo "amd64 extension does not exist, cannot publish."
+if [ ! -f ~/artifacts/honeycomb-lambda-extension-x86_64 ]; then
+    echo "x86_64 extension does not exist, cannot publish."
     exit 1;
 fi
 
@@ -25,9 +25,9 @@ fi
 
 cd ~/artifacts
 
-mkdir -p amd64/extensions
-cp honeycomb-lambda-extension-amd64 amd64/extensions/
-cd amd64
+mkdir -p x86_64/extensions
+cp honeycomb-lambda-extension-x86_64 x86_64/extensions/
+cd x86_64
 # the zipfile MUST contain a directory named "extensions"
 # and that directory MUST contain the extension's executable
 zip -r extension.zip extensions

--- a/publish.sh
+++ b/publish.sh
@@ -21,10 +21,37 @@ else
     EXTENSION_NAME="honeycomb-lambda-extension"
 fi
 
-REGIONS_NO_ARCH=(eu-north-1 us-west-1 eu-west-3 ap-northeast-2 sa-east-1 ca-central-1 af-south-1
-                ap-east-1 eu-south-1 me-south-1 ap-southeast-3 ap-northeast-3)
-REGIONS_WITH_ARCH=(ap-south-1 eu-west-2 us-east-1 eu-west-1 ap-northeast-1 ap-southeast-1
-                   ap-southeast-2 eu-central-1 us-east-2 us-west-2)
+# Region list update from AWS Lambda pricing page as of 2022/10/12
+#
+# regions with x86_64 only support
+# REGIONS_NO_ARCH=(me-central-1) # listed on pricing page, but we need grant our publishing credentials permission to publish there first
+REGIONS_NO_ARCH=()
+# Regions with x86_64 & arm64
+REGIONS_WITH_ARCH=(
+    af-south-1
+    ap-east-1
+    ap-northeast-1
+    ap-northeast-2
+    ap-northeast-3
+    ap-south-1
+    ap-southeast-1
+    ap-southeast-2
+    ap-southeast-3
+    ca-central-1
+    eu-central-1
+    eu-north-1
+    eu-south-1
+    eu-west-1
+    eu-west-2
+    eu-west-3
+    me-south-1
+    sa-east-1
+    us-east-1
+    us-east-2
+    us-west-1
+    us-west-2
+)
+
 
 results_dir="publishing"
 mkdir -p ${results_dir}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,0 @@
-package main
-
-const version = "11"


### PR DESCRIPTION
## Which problem is this PR solving?

Release woes, enumerated below with the changes.

## ~Short~ description of the changes

### Reorganize releasing

- Closes #82 
- Rename published layer in regions to `honeycomb-lambda-extension-<arch>-<version tag>` so that our layer versions will always be `:1`
- Some changes in service towards #95, but not fully producing a release.json yet

Make is good at knowing how to _make_ files. This moves the layer contents
zip creation from the publish script to the Makefile. There's some duplication,
but I think that keeps the Making more readable. CI updated to use the `zip`
make target to build the binaries _and_ the zip files for artifact storage and
workflow pass-along.

Publish script updated to record the results of AWS API calls to files instead of
to script variables or the console. With the results recorded on the filesystem,
we can see success/failures after the fact and thereby build release.json from
the data in the API responses.

### Use the CIRCLE_TAG as the version for a build

- Closes #66 

Include the build version in the user-agent (formatting updated to spec).

If the CI workflow doesn't have a tag, default to an informative version
derived from the current state of the git repository. For example, this
git describe command returns the following from the branch this commit
will land on:

    » git describe --always --tags --match "v[0-9]*" HEAD
    v10.3.0-9-g834dbcb

Which is:
* the nearest tag in history that matches the pattern
* the number of commits the branch's HEAD is away from that tag/commit
* g + the sha of current HEAD


### Test against only a single Go version

- Closes #100 

This is a project released and consumed as a binary. We only need to test
against the version of Go we build and release with.
