### PR TITLE
maint: remove interstitial linux subdir from S3 publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
             ls -l ~/artifacts/*
       - run:
           name: "S3 Release"
-          command: aws s3 cp ~/artifacts s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/ --recursive
+          command: aws s3 cp ~/artifacts/linux s3://honeycomb-builds/honeycombio/honeycomb-lambda-extension/${CIRCLE_TAG}/ --recursive
 
 workflows:
   nightly:


### PR DESCRIPTION
This is a follow-up fix to the build/release overhaul in #103.

A similar change was made in multiple places, but the publish_s3 job was missed:

* In #103 for [an OS-specific directory ZIP files will be created in](https://github.com/honeycombio/honeycomb-lambda-extension/pull/103/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R61-R90)
* In #108 for [publishing assets to the GitHub Release from the Linux-specific directory](https://github.com/honeycombio/honeycomb-lambda-extension/pull/108/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R76)

With this PR's change, the built artifacts will appear in S3 directly under the `honeycomb-lambda-extension/<VERSION>` subdirectory of the honeycomb-builds bucket to match the contents for past releases as opposed to in a `honeycomb-lambda-extension/<VERSION>/linux` subdirectory. This gets things back into alignment with [the download URL given in docs for retrieving the layer contents for use in custom Docker images](https://docs.honeycomb.io/getting-data-in/integrations/aws/aws-lambda/#installing-in-a-container-image).

