### PR TITLE
feat: configurable HTTP transport connect timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The extension is configurable via environment variables set for your lambda func
   There are other valid time units ("ns", "us"/"µs", "h"), but their use does not fit a timeout for HTTP connections made in the AWS Lambda compute environment.
   A batch send that times out has a single built-in retry; total time a lambda invocation may spend waiting is double this value.
   A very low duration may result in duplicate events, if Honeycomb data ingest is successful but slower than this timeout (rare, but possible).
+- `HONEYCOMB_CONNECT_TIMEOUT` - Optional.
+  This timeout setting configures how long it can take to establish a TCP connection to Honeycomb. This setting is useful if there are ever connectivity issues, as it allows an upload requests to fail faster and not wait until the much longer batch send timeout is reached.
+  Default: 3s (3 seconds).
+  Value should be given in a format parseable as a duration, such as "1m", "15s", or "750ms".
+  There are other valid time units ("ns", "us"/"µs", "h"), but their use does not fit a timeout for HTTP connections made in the AWS Lambda compute environment.
 
 ### Terraform Example
 

--- a/eventpublisher/eventpublisher.go
+++ b/eventpublisher/eventpublisher.go
@@ -1,0 +1,111 @@
+package eventpublisher
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultBatchSendTimeout is the default timeout for a batch send to complete end to end.
+	// This value ends up being used as the underlying libhoney-go HTTP client timeout. There
+	// is a built in retry in libhoney-go which means the overall batch send timeout
+	// is really 2x this value. Caution should be exercised when setting a lower value for this as
+	// it's possible that a large batch may not be able to complete in the allotted time.
+	DefaultBatchSendTimeout = time.Second * 15
+
+	// DefaultConnectTimeout is the default timeout waiting for a connection to initiate. This value ends
+	// up being used as the Dial timeout for the underlying libhoney-go HTTP client. This setting
+	// is critical to help reduce impact caused by connectivity issues as it allows us to
+	// fail fast and not have to wait for the much longer HTTP client timeout to occur
+	DefaultConnectTimeout = time.Second * 3
+)
+
+var (
+	log = logrus.WithFields(logrus.Fields{
+		"source": "hny-lambda-ext-eventpublisher",
+	})
+)
+
+// Config defines the configuration settings for Client
+type Config struct {
+	APIKey           string
+	Dataset          string
+	APIHost          string
+	UserAgent        string
+	BatchSendTimeout time.Duration
+	ConnectTimeout   time.Duration
+}
+
+// Client is an event publisher that is just a light wrapper around libhoney
+type Client struct {
+	libhoneyClient *libhoney.Client
+}
+
+// New returns a configured Client
+func New(config Config) (*Client, error) {
+	if config.APIKey == "" || config.Dataset == "" {
+		log.Warnln("APIKey or Dataset not set, disabling libhoney")
+		libhoneyClient, err := libhoney.NewClient(libhoney.ClientConfig{})
+		if err != nil {
+			return nil, err
+		}
+		return &Client{libhoneyClient: libhoneyClient}, nil
+	}
+
+	batchSendTimeout := config.BatchSendTimeout
+	if config.BatchSendTimeout == 0 {
+		batchSendTimeout = DefaultBatchSendTimeout
+	}
+
+	connectTimeout := config.ConnectTimeout
+	if config.ConnectTimeout == 0 {
+		connectTimeout = DefaultConnectTimeout
+	}
+
+	// httpTransport uses settings from http.DefaultTransport as starting point, but
+	// overrides the dialer connect timeout
+	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+	httpTransport.DialContext = (&net.Dialer{
+		Timeout: connectTimeout,
+	}).DialContext
+
+	libhoneyClient, err := libhoney.NewClient(libhoney.ClientConfig{
+		APIKey:  config.APIKey,
+		Dataset: config.Dataset,
+		APIHost: config.APIHost,
+		Transmission: &transmission.Honeycomb{
+			MaxBatchSize:          libhoney.DefaultMaxBatchSize,
+			BatchTimeout:          libhoney.DefaultBatchTimeout,
+			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
+			PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
+			UserAgentAddition:     config.UserAgent,
+			EnableMsgpackEncoding: true,
+			BatchSendTimeout:      batchSendTimeout,
+			Transport:             httpTransport,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		libhoneyClient: libhoneyClient,
+	}, nil
+}
+
+func (c *Client) NewEvent() *libhoney.Event {
+	return c.libhoneyClient.NewEvent()
+}
+
+func (c *Client) Flush() {
+	c.libhoneyClient.Flush()
+}
+
+func (c *Client) TxResponses() chan transmission.Response {
+	return c.libhoneyClient.TxResponses()
+}

--- a/eventpublisher/eventpublisher_test.go
+++ b/eventpublisher/eventpublisher_test.go
@@ -1,0 +1,143 @@
+package eventpublisher
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventPublisherHappyPathSend(t *testing.T) {
+	testHandler := &TestHandler{
+		sleep:        0,
+		responseCode: 200,
+		response:     []byte(`[{"status":200}]`),
+	}
+	testServer := httptest.NewServer(testHandler)
+	defer testServer.Close()
+
+	eventpublisherClient, err := New(Config{
+		APIKey:    "test-api-key",
+		Dataset:   "test-dataset",
+		UserAgent: "test-user-agent",
+		APIHost:   testServer.URL,
+	})
+	assert.Nil(t, err, "unexpected error when creating client")
+
+	err = sendTestEvent(eventpublisherClient)
+	assert.Nil(t, err, "unexpected error sending test event")
+
+	txResponse := <-eventpublisherClient.TxResponses()
+	assert.Nil(t, txResponse.Err, "unexpected error in response")
+	assert.Equal(t, 1, int(atomic.LoadInt64(&testHandler.callCount)), "expected a single client request")
+	assert.Equal(t, 200, txResponse.StatusCode)
+}
+
+func TestEventPublisherBatchSendTimeout(t *testing.T) {
+	testHandler := &TestHandler{
+		sleep:        time.Millisecond * 50,
+		responseCode: 200,
+		response:     []byte(`[{"status":200}]`),
+	}
+	testServer := httptest.NewServer(testHandler)
+	defer testServer.Close()
+
+	eventpublisherClient, err := New(Config{
+		APIKey:           "test-api-key",
+		Dataset:          "test-dataset",
+		UserAgent:        "test-user-agent",
+		APIHost:          testServer.URL,
+		BatchSendTimeout: time.Millisecond * 10,
+	})
+	assert.Nil(t, err, "unexpected error when creating client")
+
+	err = sendTestEvent(eventpublisherClient)
+	assert.Nil(t, err, "unexpected error sending test event")
+
+	txResponse := <-eventpublisherClient.TxResponses()
+	assert.Equal(t, 2, int(atomic.LoadInt64(&testHandler.callCount)), "expected 2 requests due to retry")
+	assert.NotNil(t, txResponse.Err, "expected error in response")
+	txResponseErr, ok := txResponse.Err.(net.Error)
+	assert.True(t, ok, "expected a net.Error but got %v", txResponseErr)
+	assert.True(t, txResponseErr.Timeout(), "expected error to be a timeout")
+}
+
+func TestEventPublisherConnectTimeout(t *testing.T) {
+	testHandler := &TestHandler{}
+	testServer := httptest.NewServer(testHandler)
+	testServer.Close()
+
+	eventpublisherClient, err := New(Config{
+		APIKey:         "test-api-key",
+		Dataset:        "test-dataset",
+		UserAgent:      "test-user-agent",
+		APIHost:        testServer.URL,
+		ConnectTimeout: time.Millisecond * 10,
+	})
+	assert.Nil(t, err, "unexpected error creating client")
+
+	err = sendTestEvent(eventpublisherClient)
+	assert.Nil(t, err, "unexpected error sending test event")
+
+	txResponse := <-eventpublisherClient.TxResponses()
+	assert.Equal(t, 0, int(atomic.LoadInt64(&testHandler.callCount)), "expected 0 requests as server was shutdown")
+	assert.NotNil(t, txResponse.Err, "expected response to be an error")
+	txResponseErr, ok := txResponse.Err.(net.Error)
+	assert.True(t, ok, fmt.Sprintf("expected a net.Error but got %v", txResponseErr))
+	assert.ErrorIs(t, txResponseErr, syscall.ECONNREFUSED,
+		fmt.Sprintf("expected connection refused error but got %v", txResponseErr))
+}
+
+// ###########################################
+// Test implementations
+// ###########################################
+
+// sendTestEvent creates a test event and flushes it
+func sendTestEvent(client *Client) error {
+	ev := client.NewEvent()
+	ev.Add(map[string]interface{}{
+		"duration_ms": 153.12,
+		"method":      "test",
+	})
+
+	err := ev.Send()
+	if err != nil {
+		return err
+	}
+
+	client.Flush()
+	return nil
+}
+
+// TestHandler is a handler used for mocking server responses for the underlying HTTP calls
+// made by libhoney-go
+type TestHandler struct {
+	callCount    int64
+	sleep        time.Duration
+	responseCode int
+	response     []byte
+}
+
+func (h *TestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&h.callCount, 1)
+
+	_, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "can't read body", http.StatusBadRequest)
+		return
+	}
+
+	select {
+	case <-time.After(h.sleep):
+		w.WriteHeader(h.responseCode)
+		w.Write(h.response)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,17 +16,9 @@ import (
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/honeycomb-lambda-extension/eventprocessor"
+	"github.com/honeycombio/honeycomb-lambda-extension/eventpublisher"
 	"github.com/honeycombio/honeycomb-lambda-extension/extension"
 	"github.com/honeycombio/honeycomb-lambda-extension/logsapi"
-	libhoney "github.com/honeycombio/libhoney-go"
-	"github.com/honeycombio/libhoney-go/transmission"
-)
-
-const (
-	// Waiting too long to send a batch of events can be
-	// expensive in Lambda. It's reasonable to expect a
-	// batch send to complete in this amount of time.
-	defaultBatchSendTimeout = time.Second * 15
 )
 
 var (
@@ -100,17 +92,24 @@ func main() {
 		log.Debug("Response from register: ", res)
 	}
 
-	// initialize libhoney
-	libhoneyClient, err := libhoney.NewClient(libhoneyConfig())
+	// initialize event publisher client
+	eventpublisherClient, err := eventpublisher.New(eventpublisher.Config{
+		APIKey:           apiKey,
+		Dataset:          dataset,
+		APIHost:          apiHost,
+		BatchSendTimeout: envOrElseDuration("HONEYCOMB_BATCH_SEND_TIMEOUT", eventpublisher.DefaultBatchSendTimeout),
+		ConnectTimeout:   envOrElseDuration("HONEYCOMB_CONNECT_TIMEOUT", eventpublisher.DefaultConnectTimeout),
+		UserAgent:        fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version),
+	})
 	if debug {
-		go readResponses(libhoneyClient.TxResponses())
+		go readResponses(eventpublisherClient)
 	}
 	if err != nil {
 		log.Warn("Could not initialize libhoney", err)
 	}
 
 	// initialize Logs API HTTP server
-	go logsapi.StartHTTPServer(logsServerPort, libhoneyClient)
+	go logsapi.StartHTTPServer(logsServerPort, eventpublisherClient)
 
 	// create logs api client
 	logsClient := logsapi.NewClient(runtimeAPI, logsServerPort, logsapi.BufferingOptions{
@@ -142,38 +141,7 @@ func main() {
 	}
 	log.Debug("Response from subscribe: ", subRes)
 
-	eventprocessor.New(extensionClient, libhoneyClient).Run(ctx, cancel)
-}
-
-// configure libhoney
-func libhoneyConfig() libhoney.ClientConfig {
-	if apiKey == "" || dataset == "" {
-		log.Warnln("LIBHONEY_API_KEY or LIBHONEY_DATASET not set, disabling libhoney")
-		return libhoney.ClientConfig{}
-	}
-
-	return libhoney.ClientConfig{
-		APIKey:       apiKey,
-		Dataset:      dataset,
-		APIHost:      apiHost,
-		Transmission: newTransmission(),
-	}
-}
-
-func newTransmission() *transmission.Honeycomb {
-	batchSendTimeout := envOrElseDuration("HONEYCOMB_BATCH_SEND_TIMEOUT", defaultBatchSendTimeout)
-
-	userAgent := fmt.Sprintf("honeycomb-lambda-extension/%s (%s)", version, runtime.GOARCH)
-
-	return &transmission.Honeycomb{
-		MaxBatchSize:          libhoney.DefaultMaxBatchSize,
-		BatchTimeout:          libhoney.DefaultBatchTimeout,
-		MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
-		PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
-		UserAgentAddition:     userAgent,
-		EnableMsgpackEncoding: true,
-		BatchSendTimeout:      batchSendTimeout,
-	}
+	eventprocessor.New(extensionClient, eventpublisherClient).Run(ctx, cancel)
 }
 
 // (helper) Retrieve an environment variable value by the given key,
@@ -238,8 +206,8 @@ func envOrElseDuration(key string, fallback time.Duration) time.Duration {
 	return fallback
 }
 
-func readResponses(responses chan transmission.Response) {
-	for r := range responses {
+func readResponses(client *eventpublisher.Client) {
+	for r := range client.TxResponses() {
 		var metadata string
 		if r.Metadata != nil {
 			metadata = fmt.Sprintf("%s", r.Metadata)

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 		APIHost:          apiHost,
 		BatchSendTimeout: envOrElseDuration("HONEYCOMB_BATCH_SEND_TIMEOUT", eventpublisher.DefaultBatchSendTimeout),
 		ConnectTimeout:   envOrElseDuration("HONEYCOMB_CONNECT_TIMEOUT", eventpublisher.DefaultConnectTimeout),
-		UserAgent:        fmt.Sprintf("honeycomb-lambda-extension-%s/%s", runtime.GOARCH, version),
+		UserAgent:        fmt.Sprintf("honeycomb-lambda-extension/%s (%s)", version, runtime.GOARCH),
 	})
 	if debug {
 		go readResponses(eventpublisherClient)

--- a/main_test.go
+++ b/main_test.go
@@ -4,50 +4,62 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/honeycomb-lambda-extension/eventpublisher"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Configuration_BatchSendTimeout(t *testing.T) {
+func Test_Configuration_Timeouts(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		timeoutEnvVar   string
-		expectedTimeout time.Duration
+		desc                   string
+		timeoutEnvVar          string
+		expectedBatchTimeout   time.Duration
+		expectedConnectTimeout time.Duration
 	}{
 		{
-			desc:            "default",
-			timeoutEnvVar:   "",
-			expectedTimeout: defaultBatchSendTimeout,
+			desc:                   "default",
+			timeoutEnvVar:          "",
+			expectedBatchTimeout:   eventpublisher.DefaultBatchSendTimeout,
+			expectedConnectTimeout: eventpublisher.DefaultConnectTimeout,
 		},
 		{
-			desc:            "set by user: duration seconds",
-			timeoutEnvVar:   "9s",
-			expectedTimeout: 9 * time.Second,
+			desc:                   "set by user: duration seconds",
+			timeoutEnvVar:          "9s",
+			expectedBatchTimeout:   9 * time.Second,
+			expectedConnectTimeout: 9 * time.Second,
 		},
 		{
-			desc:            "set by user: duration milliseconds",
-			timeoutEnvVar:   "900ms",
-			expectedTimeout: 900 * time.Millisecond,
+			desc:                   "set by user: duration milliseconds",
+			timeoutEnvVar:          "900ms",
+			expectedBatchTimeout:   900 * time.Millisecond,
+			expectedConnectTimeout: 900 * time.Millisecond,
 		},
 		{
-			desc:            "set by user: integer",
-			timeoutEnvVar:   "42",
-			expectedTimeout: 42 * time.Second,
+			desc:                   "set by user: integer",
+			timeoutEnvVar:          "42",
+			expectedBatchTimeout:   42 * time.Second,
+			expectedConnectTimeout: 42 * time.Second,
 		},
 		{
-			desc:            "bad input: words",
-			timeoutEnvVar:   "forty-two",
-			expectedTimeout: defaultBatchSendTimeout,
+			desc:                   "bad input: words",
+			timeoutEnvVar:          "forty-two",
+			expectedBatchTimeout:   eventpublisher.DefaultBatchSendTimeout,
+			expectedConnectTimeout: eventpublisher.DefaultConnectTimeout,
 		},
 		{
-			desc:            "bad input: unicode",
-			timeoutEnvVar:   "🤷",
-			expectedTimeout: defaultBatchSendTimeout,
+			desc:                   "bad input: unicode",
+			timeoutEnvVar:          "🤷",
+			expectedBatchTimeout:   eventpublisher.DefaultBatchSendTimeout,
+			expectedConnectTimeout: eventpublisher.DefaultConnectTimeout,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			t.Setenv("HONEYCOMB_BATCH_SEND_TIMEOUT", tC.timeoutEnvVar)
-			assert.Equal(t, tC.expectedTimeout, newTransmission().BatchSendTimeout)
+			t.Setenv("HONEYCOMB_CONNECT_TIMEOUT", tC.timeoutEnvVar)
+			assert.Equal(t, tC.expectedBatchTimeout, envOrElseDuration("HONEYCOMB_BATCH_SEND_TIMEOUT",
+				eventpublisher.DefaultBatchSendTimeout))
+			assert.Equal(t, tC.expectedConnectTimeout, envOrElseDuration("HONEYCOMB_CONNECT_TIMEOUT",
+				eventpublisher.DefaultConnectTimeout))
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

* Partially address #101 

This provides a means to configure just the connect timeout, probably the most important of the timeout settings, so limiting scope to just that.

## Short description of the changes

* A new env variable HONEYCOMB_CONNECT_TIMEOUT can be used to customize the HTTP transport connection timeout for the underlying libhoney-go client so that when there are network connectivity issues, batch upload will fail faster and not hang for the full duration of the batch upload timeout. The default connection timeout is set to 3 seconds if not specified. This closes out a portion of issue #101, as it's only handling connect timeout for now. Limiting network connection timeouts is critical for a Lambda extension as it's possible for an extension to extend the duration of a function invocation and result in function timeouts. This has real world impacts beyond just costs. This scenario can easily result in overall Lambda account concurrency limits being exceeded, which will prevent further function executions from running (essentially a denial of service). Furthermore, when function timeouts occur, this causes the underyling Lambda sandbox to terminate resulting in performance impact in the form of cold starts for all invocations.
* Refactor: move libhoney-go code out of main package and into an eventpublisher package which is just a wrapper around the libhoney client with reduced API surface that is configured with default network settings more appropriate for a Lambda extension. This move to a separate package also helps with the unit tests as this can be written outside of package main.

