### PR TITLE
remove duplicate GOARCH in user-agent

### DIFF
--- a/eventpublisher/eventpublisher.go
+++ b/eventpublisher/eventpublisher.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"runtime"
 
 	"github.com/honeycombio/honeycomb-lambda-extension/extension"
 	"github.com/honeycombio/libhoney-go"
@@ -50,7 +49,7 @@ func New(config extension.Config, version string) (*Client, error) {
 			BatchTimeout:          libhoney.DefaultBatchTimeout,
 			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:   libhoney.DefaultPendingWorkCapacity,
-			UserAgentAddition:     fmt.Sprintf("honeycomb-lambda-extension/%s (%s)", version, runtime.GOARCH),
+			UserAgentAddition:     fmt.Sprintf("honeycomb-lambda-extension/%s", version),
 			EnableMsgpackEncoding: true,
 			BatchSendTimeout:      config.BatchSendTimeout,
 			Transport:             httpTransport,


### PR DESCRIPTION
## Which problem is this PR solving?

- libhoney 1.18.0 includes GOARCH in the user-agent already, so the lambda extension does not need to repeat it

Difference in user-agent after this change:

```diff
- libhoney-go/1.18.0 honeycomb-lambda-extension/1.2.3 (amd64) go/1.19.1 (linux/amd64)
+ libhoney-go/1.18.0 honeycomb-lambda-extension/1.2.3 go/1.19.1 (linux/amd64) 
```

## Short description of the changes

- remove explicit GOARCH add in user-agent addition
- test that GOARCH still appears in the final user-agent
