### PR TITLE
maint: Update AWS regions we publish to

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ $ aws lambda publish-layer-version \
     --zip-file "fileb://artifacts/linux/extension-<ARCH>.zip"
 ```
 
+## Updating AWS regions we publish to
+
+Use the [AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/) page to get list of regions that support x86_64 and arm64.
+
+- View HTML source, navigate to dropdowns, copy whole ul element for each platform and add to local file (eg regions-x86_64.txt)
+- Tidy up content to only keep the region ids
+- Sort the file alphabetically
+  - `sort -n regions-x86_64.txt > regions-x86_64-sorted.txt`
+- Perform a diff on the two files
+  - `diff --ignore-matching-lines --side-by-side regions-arm64-sorted.txt regions-x86_64-sorted.txt`
+- Update REGIONS_WITH_ARCH (supports both x86_64 and arm64) and REGIONS_NO_ARCH (only supports x86_64) in [publish.sh](./publish.sh) with derived sets
+  - All regions should support x86_64 and a small subset will not support arm64
+
+NOTE: We may need to opt-in to a region before we can publish to it.
+The [Regions and zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) page shows if a region requires opt-in.
+
 ## Contributions
 
 Features, bug fixes and other changes to the extension are gladly accepted. Please open issues or a pull request with your change. Remember to add your name to the CONTRIBUTORS file!

--- a/README.md
+++ b/README.md
@@ -124,16 +124,19 @@ $ aws lambda publish-layer-version \
 
 Use the [AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/) page to get list of regions that support x86_64 and arm64.
 
+As of 2023-02-27, follow these instructions to more readily compare region names to region ids:
+
 - View HTML source, navigate to dropdowns, copy whole ul element for each platform and add to local file (eg regions-x86_64.txt)
 - Tidy up content to only keep the region ids
 - Sort the file alphabetically
   - `sort -n regions-x86_64.txt > regions-x86_64-sorted.txt`
 - Perform a diff on the two files
   - `diff --ignore-matching-lines --side-by-side regions-arm64-sorted.txt regions-x86_64-sorted.txt`
-- Update REGIONS_WITH_ARCH (supports both x86_64 and arm64) and REGIONS_NO_ARCH (only supports x86_64) in [publish.sh](./publish.sh) with derived sets
+- Update REGIONS_WITH_ARM (supports both x86_64 and arm64) and REGIONS_NO_ARM (only supports x86_64) in [publish.sh](./publish.sh) with derived sets
   - All regions should support x86_64 and a small subset will not support arm64
+- **Note**: the source sometimes shows all regions and should not be considered a reliable way to tell whether ARM is supported; this should be a spot check with the dropdown provided.
 
-NOTE: We may need to opt-in to a region before we can publish to it.
+NOTE: We need to opt-in to a new region before we can publish to it.
 The [Regions and zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) page shows if a region requires opt-in.
 
 ## Contributions

--- a/publish.sh
+++ b/publish.sh
@@ -23,34 +23,34 @@ EXTENSION_NAME="honeycomb-lambda-extension"
 # regions with x86_64 only support
 REGIONS_NO_ARM=(
     ap-southeast-4
-    # eu-central-2
-    # eu-south-2
-    # me-central-1
+    eu-central-2
+    eu-south-2
+    me-central-1
 )
 # Regions with x86_64 & arm64
 REGIONS_WITH_ARM=(
-    # af-south-1
-    # ap-east-1
-    # ap-northeast-1
-    # ap-northeast-2
-    # ap-northeast-3
-    # ap-south-1
-    # ap-southeast-1
-    # ap-southeast-2
-    # ap-southeast-3
-    # ca-central-1
-    # eu-central-1
-    # eu-north-1
-    # eu-south-1
-    # eu-west-1
-    # eu-west-2
-    # eu-west-3
-    # me-south-1
-    # sa-east-1
+    af-south-1
+    ap-east-1
+    ap-northeast-1
+    ap-northeast-2
+    ap-northeast-3
+    ap-south-1
+    ap-southeast-1
+    ap-southeast-2
+    ap-southeast-3
+    ca-central-1
+    eu-central-1
+    eu-north-1
+    eu-south-1
+    eu-west-1
+    eu-west-2
+    eu-west-3
+    me-south-1
+    sa-east-1
     us-east-1
-    # us-east-2
-    # us-west-1
-    # us-west-2
+    us-east-2
+    us-west-1
+    us-west-2
 )
 
 

--- a/publish.sh
+++ b/publish.sh
@@ -22,35 +22,35 @@ EXTENSION_NAME="honeycomb-lambda-extension"
 #
 # regions with x86_64 only support
 REGIONS_NO_ARM=(
-    # ap-southeast-4
+    ap-southeast-4
     # eu-central-2
     # eu-south-2
     # me-central-1
 )
 # Regions with x86_64 & arm64
 REGIONS_WITH_ARM=(
-    af-south-1
-    ap-east-1
-    ap-northeast-1
-    ap-northeast-2
-    ap-northeast-3
-    ap-south-1
-    ap-southeast-1
-    ap-southeast-2
-    ap-southeast-3
-    ca-central-1
-    eu-central-1
-    eu-north-1
-    eu-south-1
-    eu-west-1
-    eu-west-2
-    eu-west-3
-    me-south-1
-    sa-east-1
-    us-east-1
-    us-east-2
-    us-west-1
-    us-west-2
+    # af-south-1
+    # ap-east-1
+    # ap-northeast-1
+    # ap-northeast-2
+    # ap-northeast-3
+    # ap-south-1
+    # ap-southeast-1
+    # ap-southeast-2
+    # ap-southeast-3
+    # ca-central-1
+    # eu-central-1
+    # eu-north-1
+    # eu-south-1
+    # eu-west-1
+    # eu-west-2
+    # eu-west-3
+    # me-south-1
+    # sa-east-1
+    # us-east-1
+    # us-east-2
+    # us-west-1
+    # us-west-2
 )
 
 

--- a/publish.sh
+++ b/publish.sh
@@ -17,12 +17,11 @@ VERSION=$(echo ${VERSION} | tr '.' '-')
 
 EXTENSION_NAME="honeycomb-lambda-extension"
 
-# Region list update from AWS Lambda pricing page as of 2022/10/12
+# Region list update from AWS Lambda pricing page as of 2023/02/27
 # Commented out lines are listed on available but require opt-in before we can publish to it.
 #
 # regions with x86_64 only support
 REGIONS_NO_ARCH=(
-    # ap-south-1
     # ap-southeast-4
     # eu-central-2
     # eu-south-2

--- a/publish.sh
+++ b/publish.sh
@@ -47,7 +47,7 @@ REGIONS_WITH_ARM=(
     # eu-west-3
     # me-south-1
     # sa-east-1
-    # us-east-1
+    us-east-1
     # us-east-2
     # us-west-1
     # us-west-2

--- a/publish.sh
+++ b/publish.sh
@@ -18,10 +18,16 @@ VERSION=$(echo ${VERSION} | tr '.' '-')
 EXTENSION_NAME="honeycomb-lambda-extension"
 
 # Region list update from AWS Lambda pricing page as of 2022/10/12
+# Commented out lines are listed on available but require opt-in before we can publish to it.
 #
 # regions with x86_64 only support
-# REGIONS_NO_ARCH=(me-central-1) # listed on pricing page, but we need enable this region before publishing to it.
-REGIONS_NO_ARCH=()
+REGIONS_NO_ARCH=(
+    # ap-south-1
+    # ap-southeast-4
+    # eu-central-2
+    # eu-south-2
+    # me-central-1
+)
 # Regions with x86_64 & arm64
 REGIONS_WITH_ARCH=(
     af-south-1

--- a/publish.sh
+++ b/publish.sh
@@ -21,14 +21,14 @@ EXTENSION_NAME="honeycomb-lambda-extension"
 # Commented out lines are listed on available but require opt-in before we can publish to it.
 #
 # regions with x86_64 only support
-REGIONS_NO_ARCH=(
+REGIONS_NO_ARM=(
     # ap-southeast-4
     # eu-central-2
     # eu-south-2
     # me-central-1
 )
 # Regions with x86_64 & arm64
-REGIONS_WITH_ARCH=(
+REGIONS_WITH_ARM=(
     af-south-1
     ap-east-1
     ap-northeast-1
@@ -61,7 +61,7 @@ mkdir -p ${results_dir}
 
 layer_name_x86_64="${EXTENSION_NAME}-x86_64-${VERSION}"
 
-for region in ${REGIONS_WITH_ARCH[@]}; do
+for region in ${REGIONS_WITH_ARM[@]}; do
     id="x86_64-${region}"
     publish_results_json="${results_dir}/publish-${id}.json"
     permit_results_json="${results_dir}/permit-${id}.json"
@@ -79,7 +79,7 @@ for region in ${REGIONS_WITH_ARCH[@]}; do
         > "${permit_results_json}"
 done
 
-for region in ${REGIONS_NO_ARCH[@]}; do
+for region in ${REGIONS_NO_ARM[@]}; do
     id="x86_64-${region}"
     publish_results_json="${results_dir}/publish-${id}.json"
     permit_results_json="${results_dir}/permit-${id}.json"
@@ -100,7 +100,7 @@ done
 
 layer_name_arm64="${EXTENSION_NAME}-arm64-${VERSION}"
 
-for region in ${REGIONS_WITH_ARCH[@]}; do
+for region in ${REGIONS_WITH_ARM[@]}; do
     id="arm64-${region}"
     publish_results_json="${results_dir}/publish-${id}.json"
     permit_results_json="${results_dir}/permit-${id}.json"


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the list of AWS regions we publish the lambda extension to. Also adds docs to how we source the list of regions and how we determine which platforms it supports.

- Closes #121 

## Short description of the changes

- Update `publish.sh` with new regions
- Add section to README on how to get list of regions including supported platforms
- Rename from `REGIONS_NO_ARCH` and `REGIONS_WITH_ARCH` to `REGIONS_NO_ARM` and `REGIONS-WITH_ARM` for better clarity

## How to verify this has the expected result

- We published a dev tag for `ap-southeast-4` and `us-east-1` to confirm the layer appeared as expected in both regions (`honeycomb-lambda-extension-x86_64-v11-1-1-dev` in both, `honeycomb-lambda-extension-arm64-v11-1-1-dev` in `us-east-1`). Also clicked into each of the other new regions to confirm an empty layer page, so we have permissions to publish there.