### PR TITLE
rel: prepare release v11.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Honeycomb Lambda Extension Changelog
 
+## v11.1.1 - 2023-02-27
+
+### Maintenance
+
+- maint: Update AWS regions we publish to (#123) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- maint: Update CODEOWNERS (#122) | [@vreynolds](https://github.com/vreynolds)
+- chore: update dependabot.yml (#120) | [@kentquirk](https://github.com/kentquirk)
+- maint: remove duplicate GOARCH in user-agent (#117)| [@robbkidd](https://github.com/robbkidd)
+- Bump github.com/stretchr/testify from 1.8.0 to 1.8.1 (#115)
+- Bump github.com/honeycombio/libhoney-go from 1.17.0 to 1.18.0 (#116)
+
 ## v11.1.0 - 2022-10-24
 
 ### Enhancements


### PR DESCRIPTION
## Which problem is this PR solving?

- new release v11.1.1

## Short description of the changes

- update changelog with changes since last release
- post-release steps:
  - prepped docs PR to be updated and merged once this is released
  - prepped `release.json` artifact to double-check and upload to github release page

