### PR TITLE
fix: forward the sample rate from the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Honeycomb Lambda Extension Changelog
 
-## Unreleased
-
-Events that contain a sample rate (under the `samplerate` key in a JSON-formatted event) will have that sample rate
-forwarded to honeycomb
-
-### Fixed
-- fix: forward the sample rate from the message
-
 ## v11.1.2 - 2023-10-13
 
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Honeycomb Lambda Extension Changelog
 
+## Unreleased
+
+Events that contain a sample rate (under the `samplerate` key in a JSON-formatted event) will have that sample rate
+forwarded to honeycomb
+
+### Fixed
+- fix: forward the sample rate from the message
+
 ## v11.1.2 - 2023-10-13
 
 ### Maintenance

--- a/logsapi/server.go
+++ b/logsapi/server.go
@@ -117,15 +117,15 @@ func parseSampleRate(body map[string]interface{}) uint {
 	var foundRate int
 
 	if ok {
-		// duration_ms may be a float (e.g. 43.23), integer (e.g. 54) or a string (e.g. "43")
+		// samplerate may be a float (e.g. 43.23), integer (e.g. 54) or a string (e.g. "43")
 		switch sampleRate := rate.(type) {
 		case float64:
 			foundRate = int(sampleRate)
 		case int64:
 			foundRate = int(sampleRate)
 		case string:
-			if d, err := strconv.ParseInt(sampleRate, 10, 32); err == nil {
-				foundRate = int(d)
+			if d, err := strconv.Atoi(sampleRate); err == nil {
+				foundRate = d
 			}
 		}
 	}

--- a/logsapi/server.go
+++ b/logsapi/server.go
@@ -85,6 +85,7 @@ func handler(client eventCreator) http.HandlerFunc {
 						// data is not a map, so treat the record as flat JSON adding all keys as fields
 						event.Add(jsonRecord)
 					}
+					event.SampleRate = parseSampleRate(jsonRecord)
 				}
 			default:
 				// In the case of platform.start and platform.report messages, msg.Record
@@ -93,7 +94,7 @@ func handler(client eventCreator) http.HandlerFunc {
 				event.Add(msg.Record)
 			}
 			event.Metadata, _ = event.Fields()["name"]
-			event.Send()
+			event.SendPresampled()
 			log.Debug("handler - event enqueued")
 		}
 	}
@@ -109,6 +110,29 @@ func parseMessageTimestamp(event *libhoney.Event, msg LogMessage) time.Time {
 		return time.Now()
 	}
 	return ts
+}
+
+func parseSampleRate(body map[string]interface{}) uint {
+	rate, ok := body["samplerate"]
+	var foundRate int
+
+	if ok {
+		// duration_ms may be a float (e.g. 43.23), integer (e.g. 54) or a string (e.g. "43")
+		switch sampleRate := rate.(type) {
+		case float64:
+			foundRate = int(sampleRate)
+		case int64:
+			foundRate = int(sampleRate)
+		case string:
+			if d, err := strconv.ParseInt(sampleRate, 10, 32); err == nil {
+				foundRate = int(d)
+			}
+		}
+	}
+	if foundRate < 1 {
+		return 1
+	}
+	return uint(foundRate)
 }
 
 // parseFunctionTimestamp is a helper function that will return a timestamp for a function log message.

--- a/logsapi/server_test.go
+++ b/logsapi/server_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/honeycombio/libhoney-go/transmission"
-
 	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -212,4 +211,14 @@ func TestTimestampsFunctionMessageWithDuration(t *testing.T) {
 	ts = ts.Add(-1 * d)
 	assert.Equal(t, ts.String(), event.Timestamp.String())
 
+}
+
+func TestLibhoneyEventWithSampleRate(t *testing.T) {
+	events := postMessages(t, []LogMessage{{
+		Time:   epochTimestamp,
+		Type:   "function",
+		Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": 5, "data": {"foo": "bar", "duration_ms": 54} }`,
+	}})
+	event := events[0]
+	assert.EqualValues(t, 5, event.SampleRate)
 }

--- a/logsapi/server_test.go
+++ b/logsapi/server_test.go
@@ -214,11 +214,59 @@ func TestTimestampsFunctionMessageWithDuration(t *testing.T) {
 }
 
 func TestLibhoneyEventWithSampleRate(t *testing.T) {
-	events := postMessages(t, []LogMessage{{
-		Time:   epochTimestamp,
-		Type:   "function",
-		Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": 5, "data": {"foo": "bar", "duration_ms": 54} }`,
-	}})
-	event := events[0]
-	assert.EqualValues(t, 5, event.SampleRate)
+	t.Run("integer", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": 5, "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		assert.EqualValues(t, 5, event.SampleRate)
+	})
+	t.Run("float", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": 10.1, "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		// we round downwards
+		assert.EqualValues(t, 10, event.SampleRate)
+	})
+	t.Run("string", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": "11", "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		assert.EqualValues(t, 11, event.SampleRate)
+	})
+	t.Run("string without a number", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": "hello", "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		assert.EqualValues(t, 1, event.SampleRate)
+	})
+	t.Run("bool", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": true, "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		assert.EqualValues(t, 1, event.SampleRate)
+	})
+	t.Run("negative number", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time:   epochTimestamp,
+			Type:   "function",
+			Record: `{"time": "2020-12-25T12:34:56.789Z", "samplerate": -12, "data": {"foo": "bar", "duration_ms": 54} }`,
+		}})
+		event := events[0]
+		assert.EqualValues(t, 1, event.SampleRate)
+	})
 }


### PR DESCRIPTION
If the app that we're forwarding telemetry for is doing it's own
sampling, we want to honor that

Closes #145
