### PR TITLE
maint(deps): remove reviewers from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "monthly"
     labels:
       - "type: dependencies"
-    reviewers:
-      - "honeycombio/telemetry-team"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
This will use CODEOWNERS instead
