### PR TITLE
fix(eventprocessor): delay shutdown by 200ms to allow lambda app to flush

### DIFF
--- a/eventprocessor/eventprocessor.go
+++ b/eventprocessor/eventprocessor.go
@@ -3,6 +3,7 @@ package eventprocessor
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/honeycombio/honeycomb-lambda-extension/extension"
 	"github.com/honeycombio/libhoney-go"
@@ -90,6 +91,7 @@ func (s *Server) pollEventAndProcess(ctx context.Context, cancel context.CancelF
 			log.WithField("res.ShutdownReason", res.ShutdownReason).Debug("Sending shutdown reason")
 			s.sendShutdownReason(res.ShutdownReason)
 		}
+		time.Sleep(200 * time.Millisecond)
 	default:
 		log.WithField("res", res).Debug("Received unknown event")
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- Events are missing from the Lambda application instrumented with the extension, because the extension shutdown races the application's own shutdown/flush procedures. Per https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html#runtimes-lifecycle-extensions-shutdown, it can take up to 500ms for an internal extension using the sigterm handler to shut down, and we're given the shutdown for each process in parallel but our work shouldn't take the full 2k seconds.

## Short description of the changes

- Delays by 200ms before triggering flush and shutdown, to allow for telemetry from the underlying application to be sent.
