### PR TITLE
docs: add v12.0.0 changelog entry for the LMI extension fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 ### ✨ New support
 
 - AWS Lambda Managed Instances (LMI). Fixes a crash (`FunctionError.ExtensionInitError`) that made this extension unusable on LMI: LMI only allows extensions to register for the `SHUTDOWN` event (not `INVOKE`, since one execution environment handles concurrent invocations), and the extension previously treated that registration rejection as fatal. Detected automatically via `AWS_LAMBDA_INITIALIZATION_TYPE`; no configuration needed.
+- JSON log format. Functions configured with `LoggingConfig.LogFormat: JSON` (the default on new LMI functions) now have their structured telemetry parsed correctly. The Telemetry API delivers already-JSON stdout lines as pre-parsed objects and wraps plain-text lines in a `{timestamp, level, message}` envelope; previously both shapes were uploaded as a single double-encoded field with no queryable columns. No log-format changes are required in either direction — plain-text and JSON formats both work.
 
 ### Fixes
 
+- fix: parse pre-parsed JSON records from the Telemetry API (#173) | @lizthegrey
 - fix: register SHUTDOWN-only and migrate to Telemetry API on Lambda Managed Instances (#170) | @lizthegrey
 
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Honeycomb Lambda Extension Changelog
 
-## v12.0.0 - TBD
+## v12.0.0 - 2026-07-07
 
 **This is a breaking release.** It adds support for a new AWS deployment model (Lambda Managed Instances) by replacing this extension's telemetry transport outright — every function using this extension, not just ones adopting the new deployment model, now delivers logs via a different API than before. If you deploy this layer, read the breaking changes below before rolling out past a canary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Honeycomb Lambda Extension Changelog
 
+## v12.0.0 - TBD
+
+**This is a breaking release.** It adds support for a new AWS deployment model (Lambda Managed Instances) by replacing this extension's telemetry transport outright — every function using this extension, not just ones adopting the new deployment model, now delivers logs via a different API than before. If you deploy this layer, read the breaking changes below before rolling out past a canary.
+
+### 🚨 Breaking Changes
+
+- Logs API → Telemetry API. The extension no longer subscribes via the Lambda Logs API (`2020-08-15/logs`); it now uses the Telemetry API (`2022-07-01/telemetry`, `schemaVersion: 2025-01-29`) for all deployments, classic Lambda included, not just Lambda Managed Instances. AWS documents this schema version as backward-compatible with classic Lambda, but if your account/region doesn't yet support it, telemetry delivery will silently stop — the extension itself keeps running and reports healthy; there's no crash to alert on. Canary-test an actual invoke and confirm events still reach Honeycomb before rolling this out broadly.
+- Go API: the `logsapi` package is renamed to `telemetryapi`. If you import this module directly (rather than consuming the prebuilt layer), update your import paths. `extension.Client.Register()` also gained a required `managedInstances bool` parameter — existing callers must update their call sites.
+- Environment variable names (`LOGS_API_TIMEOUT_MS`, `LOGS_API_MAX_BYTES`, `LOGS_API_MAX_ITEMS`, `LOGS_API_DISABLE_PLATFORM_MSGS`) are unchanged — no Terraform/config changes needed on that front.
+
+### ✨ New support
+
+- AWS Lambda Managed Instances (LMI). Fixes a crash (`FunctionError.ExtensionInitError`) that made this extension unusable on LMI: LMI only allows extensions to register for the `SHUTDOWN` event (not `INVOKE`, since one execution environment handles concurrent invocations), and the extension previously treated that registration rejection as fatal. Detected automatically via `AWS_LAMBDA_INITIALIZATION_TYPE`; no configuration needed.
+
+### Fixes
+
+- fix: register SHUTDOWN-only and migrate to Telemetry API on Lambda Managed Instances (#170) | @lizthegrey
+
 ## v11.6.0 - 2025-11-28
 
 This release fixes a security vulnerability in Go 1.24.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 - fix: register SHUTDOWN-only and migrate to Telemetry API on Lambda Managed Instances (#170) | @lizthegrey
 
+### Maintenance
+
+- maint(deps): bump github.com/honeycombio/libhoney-go from 1.26.0 to 1.27.1 (#169) | @dependabot
+- maint(deps): bump github.com/sirupsen/logrus from 1.9.3 to 1.9.4 (#168) | @dependabot
+
 ## v11.6.0 - 2025-11-28
 
 This release fixes a security vulnerability in Go 1.24.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Maintenance
 
+- maint: bump go to 1.26 (#172) | @lizthegrey
 - maint(deps): bump github.com/honeycombio/libhoney-go from 1.26.0 to 1.27.1 (#169) | @dependabot
 - maint(deps): bump github.com/sirupsen/logrus from 1.9.3 to 1.9.4 (#168) | @dependabot
 


### PR DESCRIPTION
## Which problem is this PR solving?

Prepares the changelog for a v12.0.0 release. This is stacked on #170 and its diff will only show cleanly once that merges — opening it now so review can start in parallel, on the assumption #170 lands as-is.

## Short description of the changes

- Adds a `CHANGELOG.md` entry for v12.0.0, marked as a breaking release (not a routine minor bump) — the Telemetry API migration in #170 changes telemetry delivery behavior for existing classic-Lambda deployments, not just Lambda Managed Instances adopters.
- No code changes. `make update-licenses` was run and produced no diff (no dependency changes in #170).

**Do not tag/publish this release** until #170 is merged and the canary-rollout check called out in its review has been done — the changelog explicitly asks reviewers/operators to verify Telemetry API delivery on a real classic-Lambda invoke before rolling out broadly.