### PR TITLE
maint: bump go to 1.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   aws-cli: circleci/aws-cli@3.2.0
 
 # The Go we test and build against
-goversion: &goversion "1.25"
+goversion: &goversion "1.26"
 
 jobs:
   test:
@@ -47,7 +47,7 @@ jobs:
           path: ~/artifacts
   publish_aws:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - attach_workspace:
           at: ~/
@@ -75,7 +75,7 @@ jobs:
           command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts/linux
   publish_s3:
     docker:
-      - image: cimg/go:1.25
+      - image: cimg/go:1.26
     steps:
       - attach_workspace:
           at: ~/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/honeycomb-lambda-extension
 
-go 1.25
+go 1.26
 
 require (
 	github.com/honeycombio/libhoney-go v1.27.1


### PR DESCRIPTION
## Which problem is this PR solving?

Go 1.25 is no longer the current minor release. Staying on 1.26 keeps CI building against a supported, patched toolchain — the 1.26.x minor tag (`cimg/go:1.26`) tracks the latest patch automatically, currently 1.26.4.

## Short description of the changes

- `go.mod`: `go 1.25` → `go 1.26`
- `.circleci/config.yml`: bump the `goversion` anchor and both `cimg/go` image references from 1.25 to 1.26

This also picks up several months of upstream Go security fixes along the way (crypto/x509 CVE-2026-27137/CVE-2026-27138, html/template CVE-2026-27142, plus net/url, os, archive/tar, crypto/tls, mime, and net/textproto fixes from the 1.26.1–1.26.4 point releases).