### PR TITLE
fix: parse pre-parsed JSON records from the Telemetry API

### DIFF
--- a/telemetryapi/server.go
+++ b/telemetryapi/server.go
@@ -54,42 +54,32 @@ func handler(client eventCreator) http.HandlerFunc {
 			return
 		}
 
-		// Iterate through the batch of log messages received. In the case of function
-		// log messages, the Record field of the struct will be a string. That string
-		// may contain string-encoded JSON (e.g. "{\"trace.trace_id\": \"1234\", ...}")
-		// in which case, we will try to parse the JSON into a map[string]interface{}
-		// and then add it to the Honeycomb event. If, for some reason, parsing the JSON
-		// is impossible, then we just add the string as a field "record" in Honeycomb.
-		// This is what will happen if the function emits plain, non-structured strings.
+		// Iterate through the batch of log messages received. A function log
+		// message's Record holds whatever the function wrote to stdout, in one
+		// of two encodings. With plain-text log format (and all Logs API /
+		// pre-2022-12-13 schema deliveries), Record is a string that may itself
+		// contain JSON. With JSON log format, Lambda pre-parses the line:
+		// a line that was already JSON arrives as that object verbatim, and a
+		// non-JSON line arrives wrapped as {timestamp, level, message}.
+		// Normalize all of these into the same structured handling so a span
+		// emitted by libhoney/beeline parses identically regardless of the
+		// function's logging config.
 		for _, msg := range logs {
 			event := client.NewEvent()
 			event.AddField("lambda_extension.type", msg.Type)
 
 			switch record := msg.Record.(type) {
 			case string:
-				// attempt to parse record as json
-				var jsonRecord map[string]interface{}
-				err := json.Unmarshal([]byte(record), &jsonRecord)
-				if err != nil {
-					// not JSON; we'll treat this log entry as a timestamped string
-					event.Timestamp = parseMessageTimestamp(event, msg)
-					event.AddField("record", msg.Record)
+				addRecordString(event, msg, record)
+			case map[string]interface{}:
+				if inner, ok := record["message"].(string); ok && record["data"] == nil {
+					// JSON-log-format wrapper around a non-JSON line; unwrap and
+					// handle the original line as if it had arrived unwrapped.
+					addRecordString(event, msg, inner)
 				} else {
-					// we've got JSON
-					event.Timestamp = parseFunctionTimestamp(msg, jsonRecord)
-					switch data := jsonRecord["data"].(type) {
-					case map[string]interface{}:
-						// data key contains a map, likely emitted by a Beeline's libhoney, so add the fields from it
-						event.Add(data)
-					default:
-						// data is not a map, so treat the record as flat JSON adding all keys as fields
-						event.Add(jsonRecord)
-					}
-					event.SampleRate = parseSampleRate(jsonRecord)
+					addRecordJSON(event, msg, record)
 				}
 			default:
-				// In the case of platform.start and platform.report messages, msg.Record
-				// will be a map[string]interface{}.
 				event.Timestamp = parseMessageTimestamp(event, msg)
 				event.Add(msg.Record)
 			}
@@ -98,6 +88,33 @@ func handler(client eventCreator) http.HandlerFunc {
 			log.Debug("handler - event enqueued")
 		}
 	}
+}
+
+// addRecordString populates event from a raw log line, parsing it as JSON when
+// possible and falling back to a timestamped "record" string field.
+func addRecordString(event *libhoney.Event, msg LogMessage, record string) {
+	var jsonRecord map[string]interface{}
+	if err := json.Unmarshal([]byte(record), &jsonRecord); err != nil {
+		event.Timestamp = parseMessageTimestamp(event, msg)
+		event.AddField("record", record)
+		return
+	}
+	addRecordJSON(event, msg, jsonRecord)
+}
+
+// addRecordJSON populates event from a structured record: fields come from the
+// libhoney envelope's data map when present, otherwise from the record itself.
+func addRecordJSON(event *libhoney.Event, msg LogMessage, jsonRecord map[string]interface{}) {
+	event.Timestamp = parseFunctionTimestamp(msg, jsonRecord)
+	switch data := jsonRecord["data"].(type) {
+	case map[string]interface{}:
+		// data key contains a map, likely emitted by a Beeline's libhoney, so add the fields from it
+		event.Add(data)
+	default:
+		// data is not a map, so treat the record as flat JSON adding all keys as fields
+		event.Add(jsonRecord)
+	}
+	event.SampleRate = parseSampleRate(jsonRecord)
 }
 
 // parseMessageTimestamp is a helper function that tries to parse the timestamp from the

--- a/telemetryapi/server_test.go
+++ b/telemetryapi/server_test.go
@@ -270,3 +270,60 @@ func TestLibhoneyEventWithSampleRate(t *testing.T) {
 		assert.EqualValues(t, 1, event.SampleRate)
 	})
 }
+
+// Shapes delivered by the Telemetry API when the function's log format is
+// JSON (schema 2022-12-13+, always the case on Lambda Managed Instances):
+// a stdout line that was already JSON arrives pre-parsed as an object.
+func TestJSONFormatRecordObjects(t *testing.T) {
+	t.Run("beeline envelope arrives as pre-parsed object", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time: epochTimestamp,
+			Type: "function",
+			Record: map[string]interface{}{
+				"time":       christmasTimestamp,
+				"dataset":    "retriever-traces",
+				"samplerate": float64(5),
+				"data": map[string]interface{}{
+					"name":           "QueryKiller.Tick",
+					"trace.trace_id": "97cac7afa949e6e0ccf399e11509c275",
+					"duration_ms":    0.019234,
+				},
+			},
+		}})
+		event := events[0]
+		assert.Equal(t, "QueryKiller.Tick", event.Data["name"])
+		assert.Equal(t, "97cac7afa949e6e0ccf399e11509c275", event.Data["trace.trace_id"])
+		assert.NotContains(t, event.Data, "data", "envelope must be unwrapped, not double-encoded")
+		ts, _ := time.Parse(time.RFC3339, christmasTimestamp)
+		assert.Equal(t, ts.String(), event.Timestamp.String())
+		assert.EqualValues(t, 5, event.SampleRate)
+	})
+
+	t.Run("non-JSON line arrives wrapped in timestamp/level/message", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time: "2020-11-03T21:10:25.150Z",
+			Type: "function",
+			Record: map[string]interface{}{
+				"timestamp": "2020-11-03T21:10:25.150Z",
+				"level":     "INFO",
+				"message":   "A basic message to STDOUT",
+			},
+		}})
+		event := events[0]
+		assert.Equal(t, "A basic message to STDOUT", event.Data["record"])
+	})
+
+	t.Run("wrapped message containing JSON is unwrapped and parsed", func(t *testing.T) {
+		events := postMessages(t, []LogMessage{{
+			Time: epochTimestamp,
+			Type: "function",
+			Record: map[string]interface{}{
+				"timestamp": christmasTimestamp,
+				"level":     "INFO",
+				"message":   `{"time": "2020-12-25T12:34:56.789Z", "samplerate": 1, "data": {"foo": "bar"}}`,
+			},
+		}})
+		event := events[0]
+		assert.Equal(t, "bar", event.Data["foo"])
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Functions with JSON log format produced no queryable telemetry through this extension. With log format set to JSON (the default on new Lambda Managed Instances functions; classic functions created years ago default to plain text), the Telemetry API (schema 2022-12-13 and later) delivers a stdout line that was already JSON as a **pre-parsed object** rather than a string, and wraps non-JSON lines in a `{timestamp, level, message}` envelope. The handler only JSON-parsed **string** records, so structured spans from JSON-format functions fell into the generic path and were uploaded as a single double-encoded `data` string field — accepted by the API (202) but with no queryable columns (`name`, `trace.trace_id`, etc.). Completely silent failure.

Root-caused by capturing raw Telemetry API batch bodies on a live Lambda Managed Instances function in kibble:

```json
{"time":"...","type":"function","record":{"data":{"name":"QueryKiller.Tick","trace.trace_id":"...", ...},"time":"...","dataset":"retriever-traces"}}
```

## Short description of the changes

- `telemetryapi/server.go`: route map-shaped records through the same structured handling as parsed string records (extracted into `addRecordString`/`addRecordJSON` helpers). The `{timestamp, level, message}` plain-text wrapper is unwrapped and its `message` line re-processed, so a JSON span inside it still parses. String records (plain-text log format) take the byte-identical code path as before.
- Tests for all three new shapes, using the beeline envelope captured from the live LMI function.

## Validation

Tested against the real kibble functions with a locally built layer:
- **LMI** (`retriever-segment-processor-kibble-arm64-managed`, LogFormat JSON): before the fix, events arrived double-encoded and unqueryable; with the fix, 343 spans queryable by `name`/`global.build_id` within seconds, streaming live from all 3 execution environments.
- **Classic** (`retriever-segment-processor-kibble-arm64-versioned`, LogFormat Text): full span sets delivered and queryable (string path unchanged; delivery deferred to next-invoke/shutdown flush for isolated invokes, same as the Logs API behavior).