### PR TITLE
maint: refresh publish.sh region list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### ✨ New support
 
 - AWS Lambda Managed Instances (LMI). Fixes a crash (`FunctionError.ExtensionInitError`) that made this extension unusable on LMI: LMI only allows extensions to register for the `SHUTDOWN` event (not `INVOKE`, since one execution environment handles concurrent invocations), and the extension previously treated that registration rejection as fatal. Detected automatically via `AWS_LAMBDA_INITIALIZATION_TYPE`; no configuration needed.
+- New publishing regions. The layer is now published to ap-south-2, and arm64 layers are now published to ap-southeast-4, eu-central-2, eu-south-2, and me-central-1 (previously x86_64-only).
 - JSON log format. Functions configured with `LoggingConfig.LogFormat: JSON` (the default on new LMI functions) now have their structured telemetry parsed correctly. The Telemetry API delivers already-JSON stdout lines as pre-parsed objects and wraps plain-text lines in a `{timestamp, level, message}` envelope; previously both shapes were uploaded as a single double-encoded field with no queryable columns. No log-format changes are required in either direction — plain-text and JSON formats both work.
 
 ### Fixes

--- a/publish.sh
+++ b/publish.sh
@@ -17,15 +17,14 @@ VERSION=$(echo ${VERSION} | tr '.' '-')
 
 EXTENSION_NAME="honeycomb-lambda-extension"
 
-# Region list update from AWS Lambda pricing page as of 2023/02/27
-# Commented out lines are listed on available but require opt-in before we can publish to it.
+# Region list verified against the publishing account 2026/07/07: every region
+# the account has enabled (ec2 describe-regions) now supports arm64 Lambda
+# (probed per region with list-layer-versions --compatible-architecture arm64).
+# Regions absent here (il-central-1, ca-west-1, mx-central-1, ap-east-2,
+# ap-southeast-5/6/7) are not opted in on the publishing account.
 #
 # regions with x86_64 only support
 REGIONS_NO_ARM=(
-    ap-southeast-4
-    eu-central-2
-    eu-south-2
-    me-central-1
 )
 # Regions with x86_64 & arm64
 REGIONS_WITH_ARM=(
@@ -35,16 +34,21 @@ REGIONS_WITH_ARM=(
     ap-northeast-2
     ap-northeast-3
     ap-south-1
+    ap-south-2
     ap-southeast-1
     ap-southeast-2
     ap-southeast-3
+    ap-southeast-4
     ca-central-1
     eu-central-1
+    eu-central-2
     eu-north-1
     eu-south-1
+    eu-south-2
     eu-west-1
     eu-west-2
     eu-west-3
+    me-central-1
     me-south-1
     sa-east-1
     us-east-1


### PR DESCRIPTION
## Which problem is this PR solving?

The publish.sh region list was last updated 2023-02-27 and has drifted from reality, so releases under-publish: ap-south-2 (Hyderabad) is enabled on the publishing account but absent from the list entirely, and the four "x86_64 only" regions (ap-southeast-4, eu-central-2, eu-south-2, me-central-1) have all since gained arm64 Lambda support but weren't getting arm64 layers.

Caught while preparing the v12.0.0 release — merging this first so the new regions are covered by that release's publish run.

## Short description of the changes

- Add ap-south-2 to the publish list.
- Move ap-southeast-4, eu-central-2, eu-south-2, me-central-1 into `REGIONS_WITH_ARM`; `REGIONS_NO_ARM` is now empty (kept for future asymmetric regions — the empty-array loop is a no-op).
- Verified empirically against the publishing account: `ec2 describe-regions` for opt-in status, and a per-region `list-layer-versions --compatible-architecture arm64` probe for arm64 support. Regions still absent (il-central-1, ca-west-1, mx-central-1, ap-east-2, ap-southeast-5/6/7) are not opted in on the account — noted in the script header.
- Changelog: noted the new regions under v12.0.0.